### PR TITLE
Feature/async

### DIFF
--- a/src/AlphaVSS.Common/Classes/VssUtils.cs
+++ b/src/AlphaVSS.Common/Classes/VssUtils.cs
@@ -81,6 +81,6 @@ namespace Alphaleonis.Win32.Vss
          return (IVssImplementation)assembly.CreateInstance("Alphaleonis.Win32.Vss.VssImplementation");
       }
 
-      public static TaskFactory TaskFactory { get; set; } = new TaskFactory();
+       public static TaskFactory TaskFactory { get; set; } = new TaskFactory(TaskScheduler.Default);
    }
 }

--- a/src/AlphaVSS.Common/Classes/VssUtils.cs
+++ b/src/AlphaVSS.Common/Classes/VssUtils.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Runtime.Remoting;
 using System.Text;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace Alphaleonis.Win32.Vss
 {
@@ -79,5 +80,7 @@ namespace Alphaleonis.Win32.Vss
          Assembly assembly = Assembly.Load(GetPlatformSpecificAssemblyName());
          return (IVssImplementation)assembly.CreateInstance("Alphaleonis.Win32.Vss.VssImplementation");
       }
+
+      public static TaskFactory TaskFactory { get; set; } = new TaskFactory();
    }
 }

--- a/src/AlphaVSS.Common/Interfaces/IVssBackupComponents.cs
+++ b/src/AlphaVSS.Common/Interfaces/IVssBackupComponents.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Alphaleonis.Win32.Vss
 {
@@ -274,6 +276,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssUnexpectedWriterErrorException">An unexpected error occurred during communication with writers. The error code is logged in the error log file.</exception>
       void BackupComplete();
 
+      Task BackupCompleteAsync(CancellationToken cancellationToken);
+
       /// <summary>
       /// This method asynchronously causes VSS to generate a <b>BackupComplete</b> event, which signals writers that the backup
       /// process has completed.
@@ -439,6 +443,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssUnexpectedProviderErrorException">The provider returned an unexpected error code. This can be a transient problem. It is recommended to wait ten minutes and try again, up to three times.</exception> 
       void DoSnapshotSet();
 
+      Task DoSnapshotSetAsync(CancellationToken cancellationToken);
+
       /// <summary>
       /// Commits all shadow copies in this set simultaneously as an asynchronous operation.
       /// </summary>
@@ -587,6 +593,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssWriterInfrastructureException">The writer infrastructure is not operating properly. Check that the Event Service and VSS have been started, and check for errors associated with those services in the error log.</exception>
       void GatherWriterMetadata();
 
+      Task GatherWriterMetadataAsync(CancellationToken cancellationToken);
+
       /// <summary>
       /// 	The <see cref="BeginGatherWriterMetadata"/> method asynchronously prompts each writer to send the metadata they have collected. 
       /// 	The method will generate an <c>Identify</c> event to communicate with writers.
@@ -628,6 +636,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssBadStateException">The backup components object is not initialized, this method has been called during a restore operation, or this method has not been called within the correct sequence.</exception>		
       /// <exception cref="VssWriterInfrastructureException">The writer infrastructure is not operating properly. Check that the Event Service and VSS have been started, and check for errors associated with those services in the error log.</exception>
       void GatherWriterStatus();
+
+      Task GatherWriterStatusAsync(CancellationToken cancellationToken);
 
       /// <summary>
       /// 	The <see cref="BeginGatherWriterStatus"/> method asynchronously prompts each writer to send a status message.
@@ -786,6 +796,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssBadStateException">The backup components object is not initialized, this method has been called during a restore operation, or this method has not been called within the correct sequence.</exception>		
       void ImportSnapshots();
 
+      Task ImportSnapshotsAsync(CancellationToken cancellationToken);
+
       /// <summary>
       ///     The <see cref="BeginImportSnapshots"/> method asynchronously imports shadow copies transported from a different machine.
       /// </summary>
@@ -938,6 +950,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="VssProviderVetoException">Expected provider error. The provider logged the error in the event log.</exception>
       void PostRestore();
 
+      Task PostRestoreAsync(CancellationToken cancellationToken);
+
       /// <summary>
       ///	The <see cref="BeginPostRestore"/> method will asynchronously cause VSS to generate a <c>PostRestore</c> event, signaling writers that the current 
       ///	restore operation has finished.
@@ -988,7 +1002,9 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="SystemException">Unexpected VSS system error. The error code is logged in the event log.</exception>
       /// <exception cref="VssBadStateException">The backup components object is not initialized, this method has been called during a restore operation, or this method has not been called within the correct sequence.</exception>		
       void PrepareForBackup();
-      
+
+      Task PrepareForBackupAsync(CancellationToken cancellationToken);
+
       /// <summary>
       /// 	The <see cref="BeginPrepareForBackup"/> method will asynchronously cause VSS to generate a PrepareForBackup event, signaling writers to prepare for an upcoming 
       /// 	backup operation. This makes a requester's Backup Components Document available to writers.
@@ -1035,6 +1051,8 @@ namespace Alphaleonis.Win32.Vss
       /// <exception cref="SystemException">Unexpected VSS system error. The error code is logged in the event log.</exception>
       /// <exception cref="VssBadStateException">The backup components object is not initialized, this method has been called during a restore operation, or this method has not been called within the correct sequence.</exception>		
       void PreRestore();
+
+      Task PreRestoreAsync(CancellationToken cancellationToken);
 
       /// <summary>
       /// The <see cref="BeginPreRestore"/> method will asynchronously cause VSS to generate a <c>PreRestore</c> event, signaling writers to prepare for a 
@@ -2153,6 +2171,7 @@ namespace Alphaleonis.Win32.Vss
       /// </remarks>
       void RecoverSet(VssRecoveryOptions options);
 
+      Task RecoverSetAsync(VssRecoveryOptions options, CancellationToken cancellationToken);
 
       /// <summary>
       /// Begins an asynchronous operation that initiates a LUN resynchronization operation. This method is supported only on Windows server operating systems.

--- a/src/AlphaVSS.Platform/AlphaVSS.vcxproj
+++ b/src/AlphaVSS.Platform/AlphaVSS.vcxproj
@@ -475,6 +475,7 @@
     <ClCompile Include="Src\VssSnapshotManagement.cpp" />
     <ClCompile Include="Src\VssWMComponent.cpp" />
     <ClCompile Include="Src\VssWriterComponents.cpp" />
+    <ClCompile Include="Src\VssAsyncOperation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Include\Config.h" />
@@ -493,6 +494,7 @@
     <ClInclude Include="Include\VssSnapshotManagement.h" />
     <ClInclude Include="Include\VssWMComponent.h" />
     <ClInclude Include="Include\VssWriterComponents.h" />
+    <ClInclude Include="Include\VssAsyncOperation.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resources\AlphaVSS.rc" />

--- a/src/AlphaVSS.Platform/AlphaVSS.vcxproj.filters
+++ b/src/AlphaVSS.Platform/AlphaVSS.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="Source\VssAsyncResult.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Src\VssAsyncOperation.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Include\Config.h">
@@ -108,6 +111,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Include\VssAsyncResult.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Include\VssAsyncOperation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/AlphaVSS.Platform/Include/VssAsyncOperation.h
+++ b/src/AlphaVSS.Platform/Include/VssAsyncOperation.h
@@ -13,11 +13,9 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
     private:
         IVssAsync *m_vssAsync;
         CancellationToken m_cancellationToken;
-        TaskCompletionSource<Object^>^ m_taskCompletionSource;
         CancellationTokenRegistration^ m_cancellation;
         
         VssAsyncOperation(IVssAsync *vssAsync, CancellationToken cancellationToken);
-        void ScheduleOperation();
         void ExecuteOperation();
         void CancelAsync();
     
@@ -28,7 +26,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
         /// <summary>Releases resources used by the <see cref="VssAsyncOperation"/> object.</summary>
         !VssAsyncOperation();
 
-        property Task^ Task { virtual System::Threading::Tasks::Task^ get(); }
+        Task^ Start();
 
     internal:
         static VssAsyncOperation^ Create(IVssAsync *vssAsync, CancellationToken cancellationToken);

--- a/src/AlphaVSS.Platform/Include/VssAsyncOperation.h
+++ b/src/AlphaVSS.Platform/Include/VssAsyncOperation.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vss.h>
+
+using namespace System;
+using namespace System::Threading;
+using namespace System::Threading::Tasks;
+
+namespace Alphaleonis { namespace Win32 { namespace Vss
+{
+    private ref class VssAsyncOperation
+    {
+    private:
+        IVssAsync *m_vssAsync;
+        CancellationToken m_cancellationToken;
+        TaskCompletionSource<Object^>^ m_taskCompletionSource;
+        CancellationTokenRegistration^ m_cancellation;
+        
+        VssAsyncOperation(IVssAsync *vssAsync, CancellationToken cancellationToken);
+        void ScheduleOperation();
+        void ExecuteOperation();
+        void CancelAsync();
+    
+    public:
+        /// <summary>Destructor.</summary>
+        ~VssAsyncOperation();
+
+        /// <summary>Releases resources used by the <see cref="VssAsyncOperation"/> object.</summary>
+        !VssAsyncOperation();
+
+        property Task^ Task { virtual System::Threading::Tasks::Task^ get(); }
+
+    internal:
+        static VssAsyncOperation^ Create(IVssAsync *vssAsync, CancellationToken cancellationToken);
+    };
+}}}

--- a/src/AlphaVSS.Platform/Include/VssBackupComponents.h
+++ b/src/AlphaVSS.Platform/Include/VssBackupComponents.h
@@ -4,9 +4,12 @@
 #include "VssWriterComponents.h"
 #include "VssExamineWriterMetadata.h"
 #include "Macros.h"
+#include "VssAsyncOperation.h"
 
 using namespace System;
 using namespace System::Collections::Generic;
+using namespace System::Threading;
+using namespace System::Threading::Tasks;
 
 
 namespace Alphaleonis { namespace Win32 { namespace Vss
@@ -30,12 +33,14 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       virtual Guid AddToSnapshotSet(String^ volumeName);
 
       virtual void BackupComplete();
+      virtual Task^ BackupCompleteAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginBackupComplete(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndBackupComplete(IAsyncResult ^asyncResult);      
 
       virtual void BreakSnapshotSet(Guid snapshotSetId);
 
       virtual void BreakSnapshotSet(Guid snapshotSetId, VssHardwareOptions breakFlags);
+      virtual Task^ BreakSnapshotSetAsync(Guid snapshotSetId, VssHardwareOptions breakFlags, CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginBreakSnapshotSet(Guid snapshotSetId, VssHardwareOptions breakFlags, AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndBreakSnapshotSet(IAsyncResult ^asyncResult);      
 
@@ -46,6 +51,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       virtual void DisableWriterInstances(array<Guid> ^ writerInstanceIds);
       
       virtual void DoSnapshotSet();
+      virtual Task^ DoSnapshotSetAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginDoSnapshotSet(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndDoSnapshotSet(IAsyncResult ^asyncResult);      
 
@@ -55,10 +61,12 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       virtual void FreeWriterStatus();
 
       virtual void GatherWriterMetadata();
+      virtual Task^ GatherWriterMetadataAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginGatherWriterMetadata(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndGatherWriterMetadata(IAsyncResult ^asyncResult);
 
       virtual void GatherWriterStatus();
+      virtual Task^ GatherWriterStatusAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginGatherWriterStatus(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndGatherWriterStatus(IAsyncResult ^asyncResult);      
 
@@ -68,6 +76,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       property IList<VssWriterStatusInfo^>^ WriterStatus { virtual IList<VssWriterStatusInfo^>^ get(); }
       
       virtual void ImportSnapshots();
+      virtual Task^ ImportSnapshotsAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginImportSnapshots(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndImportSnapshots(IAsyncResult ^asyncResult);      
 
@@ -77,15 +86,18 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       virtual bool IsVolumeSupported(String^ volumeName);
       
       virtual void PostRestore();
+      virtual Task^ PostRestoreAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginPostRestore(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndPostRestore(IAsyncResult ^asyncResult);      
       
       virtual void PrepareForBackup();
+      virtual Task^ PrepareForBackupAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginPrepareForBackup(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndPrepareForBackup(IAsyncResult ^asyncResult);      
       
 
       virtual void PreRestore();
+      virtual Task^ PreRestoreAsync(CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginPreRestore(AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndPreRestore(IAsyncResult ^asyncResult);      
 
@@ -122,6 +134,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       virtual void AddSnapshotToRecoverySet(Guid snapshotId, String^ destinationVolume);
       
       virtual void RecoverSet(VssRecoveryOptions options);
+      virtual Task^ RecoverSetAsync(VssRecoveryOptions options, CancellationToken cancellationToken);
       virtual IVssAsyncResult^ BeginRecoverSet(VssRecoveryOptions options, AsyncCallback^ userCallback, Object^ stateObject);
       virtual void EndRecoverSet(IAsyncResult ^asyncResult);      
 

--- a/src/AlphaVSS.Platform/Src/VssAsyncOperation.cpp
+++ b/src/AlphaVSS.Platform/Src/VssAsyncOperation.cpp
@@ -17,7 +17,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
         }
         catch (...)
         {
-            delete m_cancellation;
+            if (m_cancellation != nullptr) delete m_cancellation;
             throw;
         }
     }

--- a/src/AlphaVSS.Platform/Src/VssAsyncOperation.cpp
+++ b/src/AlphaVSS.Platform/Src/VssAsyncOperation.cpp
@@ -1,0 +1,95 @@
+#include "stdafx.h"
+#include "VssAsyncOperation.h"
+
+using namespace System;
+using namespace System::Threading::Tasks;
+
+namespace Alphaleonis { namespace Win32 { namespace Vss
+{
+    VssAsyncOperation::VssAsyncOperation(IVssAsync *vssAsync, CancellationToken cancellationToken)
+        : m_vssAsync(vssAsync), m_cancellationToken(cancellationToken), m_taskCompletionSource(gcnew TaskCompletionSource<Object^>()), m_cancellation(nullptr)
+    {
+        if(cancellationToken != CancellationToken::None)
+            m_cancellation = cancellationToken.Register(gcnew Action(this, &VssAsyncOperation::CancelAsync));
+        try 
+        {
+            ScheduleOperation();
+        }
+        catch (...)
+        {
+            delete m_cancellation;
+            throw;
+        }
+    }
+
+    VssAsyncOperation::~VssAsyncOperation() 
+    {
+        this->!VssAsyncOperation();
+    }
+
+    VssAsyncOperation::!VssAsyncOperation()
+    {
+        if (m_cancellation != nullptr)
+        {
+            delete m_cancellation;
+            m_cancellation = nullptr;
+        }
+        if (m_vssAsync != 0)
+        {
+            m_vssAsync->Release();
+            m_vssAsync = 0;
+        }
+    }
+
+    VssAsyncOperation^ VssAsyncOperation::Create(IVssAsync *vssAsync, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return gcnew VssAsyncOperation(vssAsync, cancellationToken);
+        }
+        catch (...)
+        {
+            vssAsync->Release();
+            throw;
+        }
+    }
+
+    Task^ VssAsyncOperation::Task::get()
+    {
+        return m_taskCompletionSource->Task;
+    }
+
+    void VssAsyncOperation::ScheduleOperation()
+    {
+        VssUtils::TaskFactory->StartNew(gcnew Action(this, &VssAsyncOperation::ExecuteOperation)); 
+        // note: do not pass the cancellation token on StartNew. Even if cancellation was requested at this time, the operation needs to execute so that the result is VSS_S_ASYNC_CANCELLED.
+    }
+
+    void VssAsyncOperation::ExecuteOperation()
+    {
+        HRESULT hrResult;
+
+        hrResult = m_vssAsync->Wait();
+
+        if (SUCCEEDED(hrResult))
+        {
+            HRESULT hr = m_vssAsync->QueryStatus(&hrResult, NULL);
+            if (FAILED(hr))
+                hrResult = hr;
+        }
+
+        if (FAILED(hrResult))
+            m_taskCompletionSource->SetException(GetExceptionForHr(hrResult));
+        else if (hrResult == VSS_S_ASYNC_CANCELLED)
+            m_taskCompletionSource->SetCanceled();
+        else if (hrResult == VSS_S_ASYNC_FINISHED)
+            m_taskCompletionSource->SetResult(nullptr);
+        else // this really should not happen
+            m_taskCompletionSource->SetException(gcnew InvalidOperationException(String::Format("Operation is not complete. HResult is {0}.", hrResult)));
+    }
+
+    void VssAsyncOperation::CancelAsync() 
+    {
+        m_vssAsync->Cancel();
+    }
+}}}

--- a/src/AlphaVSS.Platform/Src/VssBackupComponents.cpp
+++ b/src/AlphaVSS.Platform/Src/VssBackupComponents.cpp
@@ -10,6 +10,8 @@
 
 using namespace System::Collections::Generic;
 using namespace System::Security::Permissions;
+using namespace System::Threading;
+using namespace System::Threading::Tasks;
 
 namespace Alphaleonis { namespace Win32 { namespace Vss
 {
@@ -139,6 +141,14 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       WaitCheckAndReleaseVssAsyncOperation(pAsync);
    }
 
+   [SecurityPermissionAttribute(SecurityAction::LinkDemand)]
+   Task^ VssBackupComponents::BackupCompleteAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->BackupComplete(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+   }
+
    IVssAsyncResult^ VssBackupComponents::BeginBackupComplete(AsyncCallback^ userCallback, Object^ stateObject)
    {
       ::IVssAsync *pAsync;
@@ -166,7 +176,18 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
 #else
       UnsupportedOs();
 #endif
-   }   
+   }
+
+   Task^ VssBackupComponents::BreakSnapshotSetAsync(Guid snapshotSetId, VssHardwareOptions breakFlags, CancellationToken cancellationToken)
+   {
+#if ALPHAVSS_TARGET >= ALPHAVSS_TARGET_WINVISTAORLATER
+       ::IVssAsync *pAsync;
+       CheckCom(RequireIVssBackupComponentsEx2()->BreakSnapshotSetEx(ToVssId(snapshotSetId), (_VSS_HARDWARE_OPTIONS)breakFlags, &pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+#else
+       UnsupportedOs();
+#endif
+   }
 
    IVssAsyncResult^ VssBackupComponents::BeginBreakSnapshotSet(Guid snapshotSetId, VssHardwareOptions breakFlags, AsyncCallback^ userCallback, Object^ stateObject)
    {
@@ -222,7 +243,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       CheckCom(m_backup->DoSnapshotSet(&vssAsync));
       WaitCheckAndReleaseVssAsyncOperation(vssAsync);
    }
-   
+
+   Task^ VssBackupComponents::DoSnapshotSetAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *vssAsync;
+       CheckCom(m_backup->DoSnapshotSet(&vssAsync));
+       return VssAsyncOperation::Create(vssAsync, cancellationToken)->Task;
+   }
 
    IVssAsyncResult^ VssBackupComponents::BeginDoSnapshotSet(AsyncCallback^ userCallback, Object^ stateObject)
    {
@@ -269,6 +296,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       WaitCheckAndReleaseVssAsyncOperation(pAsync);
    }
 
+   Task^ VssBackupComponents::GatherWriterMetadataAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->GatherWriterMetadata(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+   }
+
    IVssAsyncResult^ VssBackupComponents::BeginGatherWriterMetadata(AsyncCallback^ userCallback, Object^ stateObject)
    {
       ::IVssAsync *pAsync;
@@ -287,6 +321,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       ::IVssAsync *pAsync;
       CheckCom(m_backup->GatherWriterStatus(&pAsync));
       WaitCheckAndReleaseVssAsyncOperation(pAsync);
+   }
+
+   Task^ VssBackupComponents::GatherWriterStatusAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->GatherWriterStatus(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginGatherWriterStatus(AsyncCallback^ userCallback, Object^ stateObject)
@@ -431,6 +472,12 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       WaitCheckAndReleaseVssAsyncOperation(pAsync);
    }
 
+   Task^ VssBackupComponents::ImportSnapshotsAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->ImportSnapshots(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+   }
 
    IVssAsyncResult^ VssBackupComponents::BeginImportSnapshots(AsyncCallback^ userCallback, Object^ stateObject)
    {
@@ -476,6 +523,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       WaitCheckAndReleaseVssAsyncOperation(pAsync);
    }
 
+   Task^ VssBackupComponents::PostRestoreAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->PostRestore(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+   }
+
    IVssAsyncResult^ VssBackupComponents::BeginPostRestore(AsyncCallback^ userCallback, Object^ stateObject)
    {
       ::IVssAsync *pAsync;
@@ -496,6 +550,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       WaitCheckAndReleaseVssAsyncOperation(pAsync);      
    }
 
+   Task^ VssBackupComponents::PrepareForBackupAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->PrepareForBackup(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+   }
+
    IVssAsyncResult^ VssBackupComponents::BeginPrepareForBackup(AsyncCallback^ userCallback, Object^ stateObject)
    {
       ::IVssAsync *pAsync;
@@ -514,6 +575,13 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
       ::IVssAsync *pAsync;
       CheckCom(m_backup->PreRestore(&pAsync));
       WaitCheckAndReleaseVssAsyncOperation(pAsync);      
+   }
+
+   Task^ VssBackupComponents::PreRestoreAsync(CancellationToken cancellationToken)
+   {
+       ::IVssAsync *pAsync;
+       CheckCom(m_backup->PreRestore(&pAsync));
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginPreRestore(AsyncCallback^ userCallback, Object^ stateObject)
@@ -780,6 +848,17 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
        WaitCheckAndReleaseVssAsyncOperation(pAsync);
 #else
        UnsupportedOs();
+#endif
+    }
+
+    Task^ VssBackupComponents::RecoverSetAsync(VssRecoveryOptions options, CancellationToken cancellationToken)
+    {
+#if ALPHAVSS_TARGET >= ALPHAVSS_TARGET_WINVISTAORLATER
+        ::IVssAsync *pAsync;
+        CheckCom(RequireIVssBackupComponentsEx3()->RecoverSet((DWORD)options, &pAsync));
+        return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+#else
+        UnsupportedOs();
 #endif
     }
 

--- a/src/AlphaVSS.Platform/Src/VssBackupComponents.cpp
+++ b/src/AlphaVSS.Platform/Src/VssBackupComponents.cpp
@@ -146,7 +146,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->BackupComplete(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginBackupComplete(AsyncCallback^ userCallback, Object^ stateObject)
@@ -183,7 +183,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
 #if ALPHAVSS_TARGET >= ALPHAVSS_TARGET_WINVISTAORLATER
        ::IVssAsync *pAsync;
        CheckCom(RequireIVssBackupComponentsEx2()->BreakSnapshotSetEx(ToVssId(snapshotSetId), (_VSS_HARDWARE_OPTIONS)breakFlags, &pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
 #else
        UnsupportedOs();
 #endif
@@ -248,7 +248,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *vssAsync;
        CheckCom(m_backup->DoSnapshotSet(&vssAsync));
-       return VssAsyncOperation::Create(vssAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(vssAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginDoSnapshotSet(AsyncCallback^ userCallback, Object^ stateObject)
@@ -300,7 +300,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->GatherWriterMetadata(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginGatherWriterMetadata(AsyncCallback^ userCallback, Object^ stateObject)
@@ -327,7 +327,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->GatherWriterStatus(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginGatherWriterStatus(AsyncCallback^ userCallback, Object^ stateObject)
@@ -476,7 +476,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->ImportSnapshots(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginImportSnapshots(AsyncCallback^ userCallback, Object^ stateObject)
@@ -527,7 +527,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->PostRestore(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginPostRestore(AsyncCallback^ userCallback, Object^ stateObject)
@@ -554,7 +554,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->PrepareForBackup(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginPrepareForBackup(AsyncCallback^ userCallback, Object^ stateObject)
@@ -581,7 +581,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
    {
        ::IVssAsync *pAsync;
        CheckCom(m_backup->PreRestore(&pAsync));
-       return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+       return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
    }
 
    IVssAsyncResult^ VssBackupComponents::BeginPreRestore(AsyncCallback^ userCallback, Object^ stateObject)
@@ -856,7 +856,7 @@ namespace Alphaleonis { namespace Win32 { namespace Vss
 #if ALPHAVSS_TARGET >= ALPHAVSS_TARGET_WINVISTAORLATER
         ::IVssAsync *pAsync;
         CheckCom(RequireIVssBackupComponentsEx3()->RecoverSet((DWORD)options, &pAsync));
-        return VssAsyncOperation::Create(pAsync, cancellationToken)->Task;
+        return VssAsyncOperation::Create(pAsync, cancellationToken)->Start();
 #else
         UnsupportedOs();
 #endif

--- a/src/Samples/AlphaShadow/AlphaShadow.Bcl.Async.targets
+++ b/src/Samples/AlphaShadow/AlphaShadow.Bcl.Async.targets
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks, Version=2.6.8.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.8\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+</Project>

--- a/src/Samples/AlphaShadow/AlphaShadow.csproj
+++ b/src/Samples/AlphaShadow/AlphaShadow.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <RequiresBclAsync>false</RequiresBclAsync>
+    <RequiresBclAsync Condition="$(Configuration.StartsWith('net40'))">true</RequiresBclAsync>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45-debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -122,8 +124,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Condition="$(RequiresBclAsync)" Project="AlphaShadow.Bcl.Async.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Samples/AlphaShadow/Commands/ImportCommand.cs
+++ b/src/Samples/AlphaShadow/Commands/ImportCommand.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Alphaleonis.Win32.Vss;
 
 namespace AlphaShadow.Commands
@@ -60,6 +62,32 @@ namespace AlphaShadow.Commands
                Host.ExecCommand(GetOptionValue<string>(OptExecCommand), arguments);
             }
          }
-      }
-   }
+       }
+
+
+       public override async Task RunAsync(CancellationToken cancellationToken)
+       {
+           Host.WriteLine("Importing shadow copy set from file '{0}'", XmlDocFile);
+
+           string xmlDoc = File.ReadAllText(XmlDocFile);
+
+           Host.WriteVerbose("XML document:\n{0}", xmlDoc);
+
+           using (VssClient client = new VssClient(Host))
+           {
+               client.Initialize(VssSnapshotContext.All, xmlDoc);
+               await client.ImportSnapshotSetAsync(cancellationToken);
+
+               if (HasValue(OptExecCommand))
+               {
+                   string arguments = String.Empty;
+                   if (HasOption(CommonOptions.OptExecCommandArgs))
+                   {
+                       arguments = GetOptionValue<string>(CommonOptions.OptExecCommandArgs);
+                   }
+                   Host.ExecCommand(GetOptionValue<string>(OptExecCommand), arguments);
+               }
+           }
+       }
+    }
 }

--- a/src/Samples/AlphaShadow/Commands/ListWriterMetadataCommand.cs
+++ b/src/Samples/AlphaShadow/Commands/ListWriterMetadataCommand.cs
@@ -2,6 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace AlphaShadow.Commands
 {
    class ListWriterMetadataCommand : ContextCommand
@@ -47,5 +50,23 @@ namespace AlphaShadow.Commands
          }
       }
 
-   }
+       public override async Task RunAsync(CancellationToken cancellationToken)
+       {
+           UpdateFinalContext();
+           using (VssClient client = new VssClient(Host))
+           {
+               client.Initialize(Context);
+               if (HasOption(OptXml))
+               {
+                   await client.GatherWriterMetadataToScreenAsync(cancellationToken);
+               }
+               else
+               {
+                   await client.GatherWriterMetadataAsync(cancellationToken);
+                   client.ListWriterMetadata(HasOption(OptDetailed));
+               }
+           }
+       }
+
+    }
 }

--- a/src/Samples/AlphaShadow/Commands/ListWriterStatusCommand.cs
+++ b/src/Samples/AlphaShadow/Commands/ListWriterStatusCommand.cs
@@ -1,26 +1,38 @@
-
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AlphaShadow.Commands
 {
-   class ListWriterStatusCommand : ContextCommand
-   {
-      public ListWriterStatusCommand()
-         : base("lws", "List writer status")
-      {
-      }
+    class ListWriterStatusCommand : ContextCommand
+    {
+        public ListWriterStatusCommand()
+            : base("lws", "List writer status")
+        {
+        }
 
-      public override void Run()
-      {
-         UpdateFinalContext();
-         using (VssClient client = new VssClient(Host))
-         {
-            client.Initialize(Context);
-            client.GatherWriterMetadata();
-            client.GatherWriterStatus();
-            client.ListWriterStatus();
-         }
-      }
+        public override void Run()
+        {
+            UpdateFinalContext();
+            using (VssClient client = new VssClient(Host))
+            {
+                client.Initialize(Context);
+                client.GatherWriterMetadata();
+                client.GatherWriterStatus();
+                client.ListWriterStatus();
+            }
+        }
 
-   }
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            UpdateFinalContext();
+            using (VssClient client = new VssClient(Host))
+            {
+                client.Initialize(Context);
+                await client.GatherWriterMetadataAsync(cancellationToken);
+                await client.GatherWriterStatusAsync(cancellationToken);
+                client.ListWriterStatus();
+            }
+        }
+    }
 }

--- a/src/Samples/AlphaShadow/Commands/RestoreCommand.cs
+++ b/src/Samples/AlphaShadow/Commands/RestoreCommand.cs
@@ -4,150 +4,226 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Alphaleonis.Win32.Vss;
 
 namespace AlphaShadow.Commands
 {
-   class RestoreCommand : AlphaShadowCommand
-   {
-      private readonly OptionSpec OptFile = new OptionSpec("", OptionType.SingleValueRequired, "The previously generated Backup Components document to base the restore on.", true, "file.xml");
-      public readonly OptionSpec OptExecCommand = CommonOptions.OptExecCommand.WithHelpText("The command to execute between PreRestore and PostRestore.");
-      private readonly OptionSpec OptSimulated = new OptionSpec("simulate", OptionType.ValueProhibited, "Specified to just perform a restore simulation.", false);
+    class RestoreCommand : AlphaShadowCommand
+    {
+        private readonly OptionSpec OptFile = new OptionSpec("", OptionType.SingleValueRequired, "The previously generated Backup Components document to base the restore on.", true, "file.xml");
+        public readonly OptionSpec OptExecCommand = CommonOptions.OptExecCommand.WithHelpText("The command to execute between PreRestore and PostRestore.");
+        private readonly OptionSpec OptSimulated = new OptionSpec("simulate", OptionType.ValueProhibited, "Specified to just perform a restore simulation.", false);
 
-      public RestoreCommand()
-         : base("restore", "Restore based on a previously-generated Backup Components document")
-      {
-         
-      }
-      public override IEnumerable<OptionSpec> CommandSpecificOptions
-      {
-         get
-         {
-            return new[] { OptFile, 
-                            OptExecCommand, 
-                            CommonOptions.OptExecCommandArgs, 
-                            CommonOptions.OptVerifyWriterIncluded, 
+        public RestoreCommand()
+           : base("restore", "Restore based on a previously-generated Backup Components document")
+        {
+
+        }
+        public override IEnumerable<OptionSpec> CommandSpecificOptions
+        {
+            get
+            {
+                return new[] { OptFile,
+                            OptExecCommand,
+                            CommonOptions.OptExecCommandArgs,
+                            CommonOptions.OptVerifyWriterIncluded,
                             CommonOptions.OptExcludeWriter,
                             OptSimulated
             };
-         }
-      }
-
-      public string FileName { get; set; }
-      public HashSet<string> ExcludedWriters { get; private set; }
-      public HashSet<string> IncludedWriters { get; private set; }
-      public bool Simulate { get; set; }
-
-      protected override void ProcessOptions()
-      {
-         base.ProcessOptions();
-         ExcludedWriters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-         IncludedWriters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-         FileName = RemainingArguments.Single();
-         if (!File.Exists(FileName))
-            throw new ArgumentException(String.Format("The specified file '{0}' does not exist.", FileName));
-
-         if (HasOption(CommonOptions.OptExcludeWriter))
-         {
-            foreach (string writerName in GetOptionValues<string>(CommonOptions.OptExcludeWriter))
-            {
-               if (ExcludedWriters.Add(writerName))
-               {
-                  Host.WriteLine("(Option: Excluding writer/component '{0}')", writerName);
-               }
             }
-         }
+        }
 
-         if (HasOption(CommonOptions.OptVerifyWriterIncluded))
-         {
-            foreach (string writerName in GetOptionValues<string>(CommonOptions.OptVerifyWriterIncluded))
+        public string FileName { get; set; }
+        public HashSet<string> ExcludedWriters { get; private set; }
+        public HashSet<string> IncludedWriters { get; private set; }
+        public bool Simulate { get; set; }
+
+        protected override void ProcessOptions()
+        {
+            base.ProcessOptions();
+            ExcludedWriters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            IncludedWriters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            FileName = RemainingArguments.Single();
+            if (!File.Exists(FileName))
+                throw new ArgumentException(String.Format("The specified file '{0}' does not exist.", FileName));
+
+            if (HasOption(CommonOptions.OptExcludeWriter))
             {
-               if (ExcludedWriters.Contains(writerName))
-                  throw new ArgumentException(String.Format("A writer cannot be both included and excluded: '{0}'.", writerName));
-
-               if (IncludedWriters.Add(writerName))
-               {
-                  Host.WriteLine("(Option: Verifying inclusion of writer/component '{0}')", writerName);
-               }
-            }
-         }
-
-         Simulate = HasOption(OptSimulated);
-      }
-
-
-      public override void Run()
-      {
-         Host.WriteLine("Performing a{0} restore", Simulate ? " simulated" : "");
-
-         string xmlDoc = File.ReadAllText(FileName);
-         Host.WriteVerbose("XML Document:\n{0}", xmlDoc);
-
-         using (VssClient client = new VssClient(Host))
-         {
-            // Initialize the VSS client
-            client.Initialize(VssSnapshotContext.All, xmlDoc, true);
-
-            // Gather writer metadata
-            client.GatherWriterMetadata();
-
-            // Gather writer status
-            client.GatherWriterStatus();
-
-            // List writer status
-            client.ListWriterStatus();
-
-            // Initialize the list of writers and components for restore
-            client.InitializeWriterComponentsForRestore();
-
-            // Select required components for restore
-            client.SelectComponentsForRestore(ExcludedWriters.ToList(), IncludedWriters.ToList());
-
-            if (Simulate)
-            {
-               Host.WriteLine("Restore simulation done.");
-               return;
+                foreach (string writerName in GetOptionValues<string>(CommonOptions.OptExcludeWriter))
+                {
+                    if (ExcludedWriters.Add(writerName))
+                    {
+                        Host.WriteLine("(Option: Excluding writer/component '{0}')", writerName);
+                    }
+                }
             }
 
-            // Issue a PreRestore event to the writers
-            client.PreRestore();
-
-            // Execute the optional custom command between PreRestore and PostRestore
-            try
+            if (HasOption(CommonOptions.OptVerifyWriterIncluded))
             {
-               if (HasOption(OptExecCommand))
-               {
-                  string arguments = String.Empty;
-                  if (HasOption(CommonOptions.OptExecCommandArgs))
-                  {
-                     arguments = GetOptionValue<string>(CommonOptions.OptExecCommandArgs);
-                  }
-                  Host.ExecCommand(GetOptionValue<string>(OptExecCommand), arguments);
-               }
+                foreach (string writerName in GetOptionValues<string>(CommonOptions.OptVerifyWriterIncluded))
+                {
+                    if (ExcludedWriters.Contains(writerName))
+                        throw new ArgumentException(String.Format("A writer cannot be both included and excluded: '{0}'.", writerName));
+
+                    if (IncludedWriters.Add(writerName))
+                    {
+                        Host.WriteLine("(Option: Verifying inclusion of writer/component '{0}')", writerName);
+                    }
+                }
             }
-            catch (Exception)
+
+            Simulate = HasOption(OptSimulated);
+        }
+
+
+        public override void Run()
+        {
+            Host.WriteLine("Performing a{0} restore", Simulate ? " simulated" : "");
+
+            string xmlDoc = File.ReadAllText(FileName);
+            Host.WriteVerbose("XML Document:\n{0}", xmlDoc);
+
+            using (VssClient client = new VssClient(Host))
             {
-               // Notify writers about a failed restore
-               client.SetFileRestoreStatus(false);
+                // Initialize the VSS client
+                client.Initialize(VssSnapshotContext.All, xmlDoc, true);
 
-               // Issue a PostRestore event to the writers
-               client.PostRestore();
+                // Gather writer metadata
+                client.GatherWriterMetadata();
 
-               throw;
+                // Gather writer status
+                client.GatherWriterStatus();
+
+                // List writer status
+                client.ListWriterStatus();
+
+                // Initialize the list of writers and components for restore
+                client.InitializeWriterComponentsForRestore();
+
+                // Select required components for restore
+                client.SelectComponentsForRestore(ExcludedWriters.ToList(), IncludedWriters.ToList());
+
+                if (Simulate)
+                {
+                    Host.WriteLine("Restore simulation done.");
+                    return;
+                }
+
+                // Issue a PreRestore event to the writers
+                client.PreRestore();
+
+                // Execute the optional custom command between PreRestore and PostRestore
+                try
+                {
+                    if (HasOption(OptExecCommand))
+                    {
+                        string arguments = String.Empty;
+                        if (HasOption(CommonOptions.OptExecCommandArgs))
+                        {
+                            arguments = GetOptionValue<string>(CommonOptions.OptExecCommandArgs);
+                        }
+                        Host.ExecCommand(GetOptionValue<string>(OptExecCommand), arguments);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Notify writers about a failed restore
+                    client.SetFileRestoreStatus(false);
+
+                    // Issue a PostRestore event to the writers
+                    client.PostRestore();
+
+                    throw;
+                }
+
+                // Notify writers about a succesful restore
+                client.SetFileRestoreStatus(true);
+
+                // Issue a PostRestore event to the writers
+                client.PostRestore();
+
+                // Check selected writer status
+                client.CheckSelectedWriterStatus();
+
+                Host.WriteLine("Restore done.");
+
             }
-                        
-            // Notify writers about a succesful restore
-            client.SetFileRestoreStatus(true);
+        }
 
-            // Issue a PostRestore event to the writers
-            client.PostRestore();
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Performing a{0} restore", Simulate ? " simulated" : "");
 
-            // Check selected writer status
-            client.CheckSelectedWriterStatus();
+            string xmlDoc = File.ReadAllText(FileName);
+            Host.WriteVerbose("XML Document:\n{0}", xmlDoc);
 
-            Host.WriteLine("Restore done.");
+            using (VssClient client = new VssClient(Host))
+            {
+                // Initialize the VSS client
+                client.Initialize(VssSnapshotContext.All, xmlDoc, true);
 
-         }
-      }
-   }
+                // Gather writer metadata
+                await client.GatherWriterMetadataAsync(cancellationToken);
+
+                // Gather writer status
+                await client.GatherWriterStatusAsync(cancellationToken);
+
+                // List writer status
+                client.ListWriterStatus();
+
+                // Initialize the list of writers and components for restore
+                client.InitializeWriterComponentsForRestore();
+
+                // Select required components for restore
+                client.SelectComponentsForRestore(ExcludedWriters.ToList(), IncludedWriters.ToList());
+
+                if (Simulate)
+                {
+                    Host.WriteLine("Restore simulation done.");
+                    return;
+                }
+
+                // Issue a PreRestore event to the writers
+                await client.PreRestoreAsync(cancellationToken);
+
+                // Execute the optional custom command between PreRestore and PostRestore
+                try
+                {
+                    if (HasOption(OptExecCommand))
+                    {
+                        string arguments = String.Empty;
+                        if (HasOption(CommonOptions.OptExecCommandArgs))
+                        {
+                            arguments = GetOptionValue<string>(CommonOptions.OptExecCommandArgs);
+                        }
+                        Host.ExecCommand(GetOptionValue<string>(OptExecCommand), arguments);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Notify writers about a failed restore
+                    client.SetFileRestoreStatus(false);
+
+                    // Issue a PostRestore event to the writers
+                    await client.PostRestoreAsync(cancellationToken);
+
+                    throw;
+                }
+
+                // Notify writers about a succesful restore
+                client.SetFileRestoreStatus(true);
+
+                // Issue a PostRestore event to the writers
+                await client.PostRestoreAsync(cancellationToken);
+
+                // Check selected writer status
+                await client.CheckSelectedWriterStatusAsync(cancellationToken);
+
+                Host.WriteLine("Restore done.");
+
+            }
+        }
+    }
 }

--- a/src/Samples/AlphaShadow/Infrastructure/AlphaShadowCommand.cs
+++ b/src/Samples/AlphaShadow/Infrastructure/AlphaShadowCommand.cs
@@ -9,6 +9,7 @@ namespace AlphaShadow
    {
       protected static OptionSpec OptVerbose = new OptionSpec("verbose", OptionType.ValueProhibited, "Enables verbose tracing output.", false);
       protected static OptionSpec OptNoWrap = new OptionSpec("nowrap", OptionType.ValueProhibited, "Disables wordwrapping output text", false);
+      protected static OptionSpec OptAsync = new OptionSpec("async", OptionType.ValueProhibited, "Executes the command asynchronously.", false);
 
       public AlphaShadowCommand(string name, string description)
          : base(name, description)
@@ -27,7 +28,7 @@ namespace AlphaShadow
       {
          get
          {
-            return CommandSpecificOptions.Concat(new [] { OptVerbose, OptNoWrap });
+            return CommandSpecificOptions.Concat(new [] { OptVerbose, OptNoWrap, OptAsync });
          }
       }
 
@@ -35,6 +36,7 @@ namespace AlphaShadow
       {
          Host.VerboseOutputEnabled = HasOption(OptVerbose);
          Host.IsWordWrapEnabled = !HasOption(OptNoWrap);
+         Async = HasOption(OptAsync);
       }
    }  
 }

--- a/src/Samples/AlphaShadow/Infrastructure/Command.cs
+++ b/src/Samples/AlphaShadow/Infrastructure/Command.cs
@@ -5,6 +5,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AlphaShadow
 {
@@ -73,6 +75,8 @@ namespace AlphaShadow
             return Options.Where(opt => opt.Name.Length > 0);
          }
       }
+
+      public bool Async { get; protected set; }
       #endregion
 
       #region Protected Methods
@@ -140,6 +144,15 @@ namespace AlphaShadow
 
       public abstract void Run();
 
+       public virtual Task RunAsync(CancellationToken cancellationToken)
+       {
+           // if this method is not overridden then assume the command does not run async
+           // log a warning and run it synchronously
+           Host.WriteWarning("This action is not async. It will be executed synchronously instead.");
+           Run();
+           return Task.FromResult<object>(null);
+       }
+
       public virtual void Initialize(IUIHost host, IEnumerable<string> args)
       {
          if (host == null)
@@ -190,7 +203,7 @@ namespace AlphaShadow
             }
             else
             {
-               throw new ArgumentException(String.Format("Unrecognized option \"{0}\"", argument));
+                throw new ArgumentException(String.Format("Unrecognized option \"{0}\"", argument));
             }
          }
 
@@ -222,6 +235,6 @@ namespace AlphaShadow
 
       }
 
-      #endregion
+       #endregion
    }
 }

--- a/src/Samples/AlphaShadow/Infrastructure/Command.cs
+++ b/src/Samples/AlphaShadow/Infrastructure/Command.cs
@@ -144,13 +144,14 @@ namespace AlphaShadow
 
       public abstract void Run();
 
-       public virtual Task RunAsync(CancellationToken cancellationToken)
+#pragma warning disable 1998 // by design
+       public virtual async Task RunAsync(CancellationToken cancellationToken)
+#pragma warning restore 1998
        {
            // if this method is not overridden then assume the command does not run async
            // log a warning and run it synchronously
            Host.WriteWarning("This action is not async. It will be executed synchronously instead.");
            Run();
-           return Task.FromResult<object>(null);
        }
 
       public virtual void Initialize(IUIHost host, IEnumerable<string> args)

--- a/src/Samples/AlphaShadow/Program.cs
+++ b/src/Samples/AlphaShadow/Program.cs
@@ -12,6 +12,7 @@ using AlphaShadow.Commands;
 using Alphaleonis.Win32.Vss;
 using System.EnterpriseServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 
 namespace AlphaShadow
@@ -77,11 +78,23 @@ namespace AlphaShadow
          {
             Command command = GetCommand(commandName);
             command.Initialize(Host, args.Skip(1));
-            command.Run();
+             if (!command.Async)
+             {
+                 command.Run();
+             }
+             else
+             {
+                 var task = command.RunAsync(CancellationToken.None);
+                 task.GetAwaiter().GetResult();
+             }
          }
          catch (CommandAbortedException)
          {
             Host.WriteError("Execution aborted.");
+         }
+         catch (OperationCanceledException)
+         {
+            Host.WriteWarning("Execution was canceled");
          }
          catch (Exception ex)
          {

--- a/src/Samples/AlphaShadow/VssClient.cs
+++ b/src/Samples/AlphaShadow/VssClient.cs
@@ -9,1303 +9,1457 @@ using Alphaleonis.Win32.Filesystem;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AlphaShadow
 {
 
-   public class VssClient : IDisposable
-   {
-      #region Private Fields
+    public class VssClient : IDisposable
+    {
+        #region Private Fields
 
-      private List<VssWriterDescriptor> m_writerComponentsForRestore;
-      private static IVssImplementation s_implementation;
-      private VssVolumeSnapshotAttributes m_context = (VssVolumeSnapshotAttributes)VssSnapshotContext.Backup;
-      private IVssBackupComponents m_backupComponents;
-      private bool m_duringRestore;
-      private List<VssWriterDescriptor> m_writers;
-      private Guid m_latestSnapshotSetId;
-      private IList<string> m_latestVolumeList;
-      private List<Guid> m_latestSnapshotIdList = new List<Guid>();
+        private List<VssWriterDescriptor> m_writerComponentsForRestore;
+        private static IVssImplementation s_implementation;
+        private VssVolumeSnapshotAttributes m_context = (VssVolumeSnapshotAttributes) VssSnapshotContext.Backup;
+        private IVssBackupComponents m_backupComponents;
+        private bool m_duringRestore;
+        private List<VssWriterDescriptor> m_writers;
+        private Guid m_latestSnapshotSetId;
+        private IList<string> m_latestVolumeList;
+        private List<Guid> m_latestSnapshotIdList = new List<Guid>();
 
-      #endregion
+        #endregion
 
-      #region Constructor
+        #region Constructor
 
-      public VssClient(IUIHost host)
-      {
-         if (host == null)
-            throw new ArgumentNullException("host", "host is null.");
+        public VssClient(IUIHost host)
+        {
+            if (host == null)
+                throw new ArgumentNullException("host", "host is null.");
 
-         Host = host;
-      }
+            Host = host;
+        }
 
-      #endregion
+        #endregion
 
-      #region Properties
+        #region Properties
 
-      public IUIHost Host { get; private set; }
+        public IUIHost Host { get; private set; }
 
-      public static IVssImplementation Implementation
-      {
-         get
-         {
-            if (s_implementation == null)
+        public static IVssImplementation Implementation
+        {
+            get
             {
-               s_implementation = VssUtils.LoadImplementation();
+                if (s_implementation == null)
+                {
+                    s_implementation = VssUtils.LoadImplementation();
+                }
+                return s_implementation;
             }
-            return s_implementation;
-         }
-      }
+        }
 
-      #endregion
+        #endregion
 
-      #region Public Methods
+        #region Public Methods
 
-      public void Initialize(VssVolumeSnapshotAttributes context, string xmlDoc = null, bool duringRestore = false)
-      {
-         Initialize((VssSnapshotContext)context, xmlDoc, duringRestore);
-      }
+        public void Initialize(VssVolumeSnapshotAttributes context, string xmlDoc = null, bool duringRestore = false)
+        {
+            Initialize((VssSnapshotContext) context, xmlDoc, duringRestore);
+        }
 
-      public void Initialize(VssSnapshotContext context, string xmlDoc = null, bool duringRestore = false)
-      {
-         m_backupComponents = Implementation.CreateVssBackupComponents();
-         m_duringRestore = duringRestore;
+        public void Initialize(VssSnapshotContext context, string xmlDoc = null, bool duringRestore = false)
+        {
+            m_backupComponents = Implementation.CreateVssBackupComponents();
+            m_duringRestore = duringRestore;
 
-         if (m_duringRestore)
-         {
-            Host.WriteVerbose("- Calling IVssBackupComponents.InitializeForRestore() {0} xml doc.", xmlDoc == null ? "without" : "with");
-            m_backupComponents.InitializeForRestore(xmlDoc);
-         }
-         else
-         {
-            Host.WriteVerbose("- Calling IVssBackupComponents.InitializeForBackup() {0} xml doc.", xmlDoc == null ? "without" : "with");
-            m_backupComponents.InitializeForBackup(xmlDoc);
-
-            if (OperatingSystemInfo.IsAtLeast(OSVersionName.WindowsServer2003) && context != VssSnapshotContext.Backup)
+            if (m_duringRestore)
             {
-               Host.WriteLine("- Setting the VSS context to: {0}", context);
-               m_backupComponents.SetContext(context);
+                Host.WriteVerbose("- Calling IVssBackupComponents.InitializeForRestore() {0} xml doc.", xmlDoc == null ? "without" : "with");
+                m_backupComponents.InitializeForRestore(xmlDoc);
             }
-         }
-
-         m_context = (VssVolumeSnapshotAttributes)context;
-
-         m_backupComponents.SetBackupState(true, true, VssBackupType.Full, false);
-      }
-
-      public void QuerySnapshotSet(Guid snapshotSetId)
-      {
-         if (snapshotSetId == Guid.Empty)
-            Host.WriteLine("- Querying all shadow copies in the system...");
-         else
-            Host.WriteLine("- Querying all shadow copies with the SnapshotSetID {0:B}...", snapshotSetId);
-
-         Host.WriteVerbose("- Calling IVssBackupComponents.QuerySnapshots()");
-         IEnumerable<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots();
-
-         if (!snapshots.Any())
-            Host.WriteHeader("There are no snapshots in the system.");
-
-         foreach (VssSnapshotProperties props in snapshots)
-         {
-            if (snapshotSetId == Guid.Empty || props.SnapshotSetId == snapshotSetId)
+            else
             {
-               PrintSnapshotProperties(props);
-            }
-         }
-      }
+                Host.WriteVerbose("- Calling IVssBackupComponents.InitializeForBackup() {0} xml doc.", xmlDoc == null ? "without" : "with");
+                m_backupComponents.InitializeForBackup(xmlDoc);
 
-      public void GetSnapshotProperties(Guid snapshotId)
-      {
-         Host.WriteLine("- Getting properties for snapshot with ID {0:B}", snapshotId);
-         Host.WriteVerbose("- Calling IVssBackupComponents.GetSnapshotProperties({0:B})", snapshotId);
-         VssSnapshotProperties props = m_backupComponents.GetSnapshotProperties(snapshotId);
-         PrintSnapshotProperties(props);
-      }
-
-      public void CreateSnapshot(IEnumerable<string> volumeList, string outputXmlFile, IEnumerable<string> excludedWriterList, IEnumerable<string> includedWriterList)
-      {
-         bool snapshotWithWriters = (m_context & VssVolumeSnapshotAttributes.NoWriters) == 0;
-
-         if (snapshotWithWriters)
-         {
-            // Gather writer metadata
-            GatherWriterMetadata();
-
-            // Select writer components based on the given shadow volume list
-            SelectComponentsForBackup(volumeList, excludedWriterList, includedWriterList);
-         }
-
-         // Start the shadow set
-         m_latestSnapshotSetId = m_backupComponents.StartSnapshotSet();
-         Host.WriteLine("Creating shadow set {0:B}...", m_latestSnapshotSetId);
-
-         // Add the specified volumes to the shadow set
-         AddToSnapshotSet(volumeList);
-
-         // Prepare for backup. 
-         // This will internally create the backup components document with the selected components
-         if (snapshotWithWriters)
-            PrepareForBackup();
-
-         // Create the shadow set 
-         DoSnapshotSet();
-
-         // Do not attempt to continue with delayed snapshot ...
-         if ((m_context & VssVolumeSnapshotAttributes.DelayedPostSnapshot) != 0)
-         {
-            Host.WriteLine("Fast snapshot created. Exiting...");
-            return;
-         }
-
-         // Saves the backup components document, if needed
-         if (!String.IsNullOrEmpty(outputXmlFile))
-            SaveBackupComponentsDocument(outputXmlFile);
-
-         // List all the created shadow copies
-         if ((m_context & VssVolumeSnapshotAttributes.Transportable) == 0)
-         {
-            Host.WriteLine("List of created shadow copies:");
-            QuerySnapshotSet(m_latestSnapshotSetId);
-         }
-      }
-
-      private void SaveBackupComponentsDocument(string outputXmlFile)
-      {
-         Host.WriteLine("Saving the backup components document ... ");
-         
-         File.WriteAllText(outputXmlFile, m_backupComponents.SaveAsXml(), Encoding.Unicode);
-      }
-
-      private void DoSnapshotSet()
-      {
-         Host.WriteLine("Creating the shadow (DoSnapshotSet)...");
-
-         m_backupComponents.DoSnapshotSet();
-
-         if ((m_context & VssVolumeSnapshotAttributes.DelayedPostSnapshot) != 0)
-         {
-            Host.WriteLine("Fast DoSnapshotSet finished.");
-            return;
-         }
-
-         CheckSelectedWriterStatus();
-
-         Host.WriteLine("Shadow copy set successfully created.");
-      }
-
-      private void PrepareForBackup()
-      {
-         Host.WriteLine("Preparing for backup ... ");
-
-         m_backupComponents.PrepareForBackup();
-
-         // Check selected writer status
-         CheckSelectedWriterStatus();
-      }
-
-      internal void CheckSelectedWriterStatus()
-      {
-         if ((m_context & VssVolumeSnapshotAttributes.NoWriters) != 0)
-            return;
-
-
-         // Gather writer status to detect potential errors
-         GatherWriterStatus();
-
-         // Gets the number of writers in the gathered status info
-         // (WARNING: GatherWriterStatus must be called before)
-         foreach (VssWriterStatusInfo writer in m_backupComponents.WriterStatus)
-         {
-            if (!IsWriterSelected(writer.InstanceId))
-               continue;
-
-            switch (writer.State)
-            {
-               case VssWriterState.FailedAtIdentify:
-               case VssWriterState.FailedAtPrepareBackup:
-               case VssWriterState.FailedAtPrepareSnapshot:
-               case VssWriterState.FailedAtFreeze:
-               case VssWriterState.FailedAtThaw:
-               case VssWriterState.FailedAtPostSnapshot:
-               case VssWriterState.FailedAtBackupComplete:
-               case VssWriterState.FailedAtPreRestore:
-               case VssWriterState.FailedAtPostRestore:
-               case VssWriterState.FailedAtBackupShutdown:
-                  break;
-               default:
-                  continue;
+                if (OperatingSystemInfo.IsAtLeast(OSVersionName.WindowsServer2003) && context != VssSnapshotContext.Backup)
+                {
+                    Host.WriteLine("- Setting the VSS context to: {0}", context);
+                    m_backupComponents.SetContext(context);
+                }
             }
 
-            // Print writer status
-            Host.WriteError("Selected writer '{0}' is in failed state!", writer.Name);
-            Host.WriteTable(new StringTable(
-               new[] 
-               {
+            m_context = (VssVolumeSnapshotAttributes) context;
+
+            m_backupComponents.SetBackupState(true, true, VssBackupType.Full, false);
+        }
+
+        public void QuerySnapshotSet(Guid snapshotSetId)
+        {
+            if (snapshotSetId == Guid.Empty)
+                Host.WriteLine("- Querying all shadow copies in the system...");
+            else
+                Host.WriteLine("- Querying all shadow copies with the SnapshotSetID {0:B}...", snapshotSetId);
+
+            Host.WriteVerbose("- Calling IVssBackupComponents.QuerySnapshots()");
+            IEnumerable<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots();
+
+            if (!snapshots.Any())
+                Host.WriteHeader("There are no snapshots in the system.");
+
+            foreach (VssSnapshotProperties props in snapshots)
+            {
+                if (snapshotSetId == Guid.Empty || props.SnapshotSetId == snapshotSetId)
+                {
+                    PrintSnapshotProperties(props);
+                }
+            }
+        }
+
+        public void GetSnapshotProperties(Guid snapshotId)
+        {
+            Host.WriteLine("- Getting properties for snapshot with ID {0:B}", snapshotId);
+            Host.WriteVerbose("- Calling IVssBackupComponents.GetSnapshotProperties({0:B})", snapshotId);
+            VssSnapshotProperties props = m_backupComponents.GetSnapshotProperties(snapshotId);
+            PrintSnapshotProperties(props);
+        }
+
+        public void CreateSnapshot(IEnumerable<string> volumeList, string outputXmlFile, IEnumerable<string> excludedWriterList, IEnumerable<string> includedWriterList)
+        {
+            bool snapshotWithWriters = (m_context & VssVolumeSnapshotAttributes.NoWriters) == 0;
+
+            if (snapshotWithWriters)
+            {
+                // Gather writer metadata
+                GatherWriterMetadata();
+
+                // Select writer components based on the given shadow volume list
+                SelectComponentsForBackup(volumeList, excludedWriterList, includedWriterList);
+            }
+
+            // Start the shadow set
+            m_latestSnapshotSetId = m_backupComponents.StartSnapshotSet();
+            Host.WriteLine("Creating shadow set {0:B}...", m_latestSnapshotSetId);
+
+            // Add the specified volumes to the shadow set
+            AddToSnapshotSet(volumeList);
+
+            // Prepare for backup. 
+            // This will internally create the backup components document with the selected components
+            if (snapshotWithWriters)
+                PrepareForBackup();
+
+            // Create the shadow set 
+            DoSnapshotSet();
+
+            CreateSnapshotAsync_After(outputXmlFile);
+        }
+
+        public async Task CreateSnapshotAsync(IEnumerable<string> volumeList, string outputXmlFile, IEnumerable<string> excludedWriterList, IEnumerable<string> includedWriterList, CancellationToken cancellationToken)
+        {
+            bool snapshotWithWriters = (m_context & VssVolumeSnapshotAttributes.NoWriters) == 0;
+
+            if (snapshotWithWriters)
+            {
+                // Gather writer metadata
+                await GatherWriterMetadataAsync(cancellationToken);
+
+                // Select writer components based on the given shadow volume list
+                SelectComponentsForBackup(volumeList, excludedWriterList, includedWriterList);
+            }
+
+            // Start the shadow set
+            m_latestSnapshotSetId = m_backupComponents.StartSnapshotSet();
+            Host.WriteLine("Creating shadow set {0:B}...", m_latestSnapshotSetId);
+
+            // Add the specified volumes to the shadow set
+            AddToSnapshotSet(volumeList);
+
+            // Prepare for backup. 
+            // This will internally create the backup components document with the selected components
+            if (snapshotWithWriters)
+                await PrepareForBackupAsync(cancellationToken);
+
+            // Create the shadow set 
+            await DoSnapshotSetAsync(cancellationToken);
+
+            CreateSnapshotAsync_After(outputXmlFile);
+        }
+
+        private void CreateSnapshotAsync_After(string outputXmlFile)
+        {
+            // Do not attempt to continue with delayed snapshot ...
+            if ((m_context & VssVolumeSnapshotAttributes.DelayedPostSnapshot) != 0)
+            {
+                Host.WriteLine("Fast snapshot created. Exiting...");
+                return;
+            }
+
+            // Saves the backup components document, if needed
+            if (!String.IsNullOrEmpty(outputXmlFile))
+                SaveBackupComponentsDocument(outputXmlFile);
+
+            // List all the created shadow copies
+            if ((m_context & VssVolumeSnapshotAttributes.Transportable) == 0)
+            {
+                Host.WriteLine("List of created shadow copies:");
+                QuerySnapshotSet(m_latestSnapshotSetId);
+            }
+        }
+
+        private void SaveBackupComponentsDocument(string outputXmlFile)
+        {
+            Host.WriteLine("Saving the backup components document ... ");
+
+            File.WriteAllText(outputXmlFile, m_backupComponents.SaveAsXml(), Encoding.Unicode);
+        }
+
+        private void DoSnapshotSet()
+        {
+            Host.WriteLine("Creating the shadow (DoSnapshotSet)...");
+
+            m_backupComponents.DoSnapshotSet();
+
+            if ((m_context & VssVolumeSnapshotAttributes.DelayedPostSnapshot) != 0)
+            {
+                Host.WriteLine("Fast DoSnapshotSet finished.");
+                return;
+            }
+
+            CheckSelectedWriterStatus();
+
+            Host.WriteLine("Shadow copy set successfully created.");
+        }
+
+        private async Task DoSnapshotSetAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Creating the shadow (DoSnapshotSet)...");
+
+            await m_backupComponents.DoSnapshotSetAsync(cancellationToken);
+
+            if ((m_context & VssVolumeSnapshotAttributes.DelayedPostSnapshot) != 0)
+            {
+                Host.WriteLine("Fast DoSnapshotSet finished.");
+                return;
+            }
+
+            await CheckSelectedWriterStatusAsync(cancellationToken);
+
+            Host.WriteLine("Shadow copy set successfully created.");
+        }
+
+        private void PrepareForBackup()
+        {
+            Host.WriteLine("Preparing for backup ... ");
+
+            m_backupComponents.PrepareForBackup();
+
+            // Check selected writer status
+            CheckSelectedWriterStatus();
+        }
+
+        private async Task PrepareForBackupAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Preparing for backup ... ");
+
+            await m_backupComponents.PrepareForBackupAsync(cancellationToken);
+
+            // Check selected writer status
+            CheckSelectedWriterStatus();
+        }
+
+        internal void CheckSelectedWriterStatus()
+        {
+            if ((m_context & VssVolumeSnapshotAttributes.NoWriters) != 0)
+                return;
+
+            // Gather writer status to detect potential errors
+            GatherWriterStatus();
+
+            CheckSelectedWriterStatus_After();
+        }
+
+        internal async Task CheckSelectedWriterStatusAsync(CancellationToken cancellationToken)
+        {
+            if ((m_context & VssVolumeSnapshotAttributes.NoWriters) != 0)
+                return;
+
+            // Gather writer status to detect potential errors
+            await GatherWriterStatusAsync(cancellationToken);
+
+            CheckSelectedWriterStatus_After();
+        }
+
+        private void CheckSelectedWriterStatus_After()
+        {
+            // Gets the number of writers in the gathered status info
+            // (WARNING: GatherWriterStatus must be called before)
+            foreach (VssWriterStatusInfo writer in m_backupComponents.WriterStatus)
+            {
+                if (!IsWriterSelected(writer.InstanceId))
+                    continue;
+
+                switch (writer.State)
+                {
+                    case VssWriterState.FailedAtIdentify:
+                    case VssWriterState.FailedAtPrepareBackup:
+                    case VssWriterState.FailedAtPrepareSnapshot:
+                    case VssWriterState.FailedAtFreeze:
+                    case VssWriterState.FailedAtThaw:
+                    case VssWriterState.FailedAtPostSnapshot:
+                    case VssWriterState.FailedAtBackupComplete:
+                    case VssWriterState.FailedAtPreRestore:
+                    case VssWriterState.FailedAtPostRestore:
+                    case VssWriterState.FailedAtBackupShutdown:
+                        break;
+                    default:
+                        continue;
+                }
+
+                // Print writer status
+                Host.WriteError("Selected writer '{0}' is in failed state!", writer.Name);
+                Host.WriteTable(new StringTable(
+                   new[]
+                   {
                   "Status",
                   "Writer Failure Code",
                   "Writer ID",
                   "Instance ID",
-               },
-               new object[]
-               {
+                   },
+                   new object[]
+                   {
                   writer.State,
                   writer.Failure,
                   writer.ClassId,
                   writer.InstanceId
-               }));
+                   }));
+                throw new CommandAbortedException();
+            }
+        }
+
+        private bool IsWriterSelected(Guid guid)
+        {
+            return m_writers.Any(writer => writer.WriterMetadata.InstanceId == guid && !writer.IsExcluded);
+        }
+
+        private void AddToSnapshotSet(IEnumerable<string> volumeList)
+        {
+            // Preserve the list of volumes for script generation 
+            m_latestVolumeList = new List<string>(volumeList);
+
+            // Add volumes to the shadow set 
+            foreach (string volume in volumeList)
+            {
+                Host.WriteLine("- Adding volume {0} [{1}] to the shadow set...", volume, Volume.GetDisplayNameForVolume(volume));
+                m_latestSnapshotIdList.Add(m_backupComponents.AddToSnapshotSet(volume));
+            }
+        }
+
+        private void SelectComponentsForBackup(IEnumerable<string> shadowSourceVolumes, IEnumerable<string> excludedWriterList, IEnumerable<string> includedWriterList)
+        {
+            // First, exclude all components that have data outside of the shadow set
+            DiscoverDirectlyExcludedComponents(excludedWriterList, m_writers);
+
+            // Then discover excluded components that have file groups outside the shadow set
+            DiscoverNonShadowedExcludedComponents(shadowSourceVolumes);
+
+            // Now, exclude all componenets that are have directly excluded descendents
+            DiscoverAllExcludedComponents();
+
+            // Next, exclude all writers that:
+            // - either have a top-level nonselectable excluded component
+            // - or do not have any included components (all its components are excluded)
+            DiscoverExcludedWriters();
+
+            // Now, discover the components that should be included (explicitly or implicitly)
+            // These are the top components that do not have any excluded children
+            DiscoverExplicitelyIncludedComponents();
+
+            Host.WriteLine("Verifying explicitly specified writers/components...");
+
+            foreach (string include in includedWriterList)
+            {
+                if (include.Contains(':'))
+                    VerifyExplicitlyIncludedComponent(include, m_writers);
+                else
+                    VerifyExplicitlyIncludedWriter(include, m_writers);
+            }
+
+            // Finally, select the explicitly included components
+            SelectExplicitelyIncludedComponents();
+        }
+
+        private void SelectExplicitelyIncludedComponents()
+        {
+            Host.WriteLine("Select explicitly included components ...");
+
+            foreach (VssWriterDescriptor writer in m_writers.Where(w => !w.IsExcluded))
+            {
+                Host.WriteLine(" * Writer '{0}':", writer.WriterMetadata.WriterName);
+
+                // Compute the roots of included components
+                foreach (var component in writer.ComponentDescriptors.Where(c => c.IsExplicitlyIncluded))
+                {
+                    Host.WriteLine("    - Add component {0}", component.FullPath);
+                    m_backupComponents.AddComponent(writer.WriterMetadata.InstanceId, writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName);
+                }
+            }
+        }
+
+        private void VerifyExplicitlyIncludedComponent(string include, List<VssWriterDescriptor> writerList)
+        {
+            Host.WriteLine("- Verifying component \"{0}\"...", include);
+
+            foreach (VssWriterDescriptor writer in writerList.Where(w => !w.IsExcluded))
+            {
+                // Find the associated component
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
+                {
+                    if (include.Equals(writer.WriterMetadata.WriterName + ":" + component.FullPath) ||
+                        include.Equals(writer.WriterMetadata.WriterId.ToString("B") + ":" + component.FullPath, StringComparison.OrdinalIgnoreCase) ||
+                        include.Equals(writer.WriterMetadata.InstanceId.ToString("B") + ":" + component.FullPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Host.WriteVerbose("- Found component '{0}' from writer '{1}.", component.FullPath, writer.WriterMetadata.WriterName);
+
+                        // If we are during restore, we just found our component
+                        if (m_duringRestore)
+                        {
+                            Host.WriteLine(" - The component \"{0}\" is selected.", include);
+                            return;
+                        }
+
+                        // If not explicitly included, check to see if there is an explicitly included ancestor
+                        bool isIncluded = component.IsExplicitlyIncluded;
+                        if (!isIncluded)
+                        {
+                            isIncluded = writer.ComponentDescriptors.Any(ancestor => ancestor.IsAncestorOf(component) && ancestor.IsExplicitlyIncluded);
+                        }
+
+                        if (isIncluded)
+                        {
+                            Host.WriteLine(" - The component \"{0}\" is selected.", include);
+                            return;
+                        }
+                        else
+                        {
+                            Host.WriteError("The component \"{0}\" was not included in the backup! Aborting backup...", include);
+                            Host.WriteError("- Please reveiw the component/subcomponent definitions");
+                            Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
+                            throw new CommandAbortedException();
+                        }
+                    }
+                }
+            }
+
+            Host.WriteError("The component \"{0}\" was not found in the writer components list! Aborting backup ...", include);
+            Host.WriteError("- Please check the syntax of the component name.");
             throw new CommandAbortedException();
-         }
-      }
+        }
 
-      private bool IsWriterSelected(Guid guid)
-      {
-         return m_writers.Any(writer => writer.WriterMetadata.InstanceId == guid && !writer.IsExcluded);
-      }
+        private void VerifyExplicitlyIncludedWriter(string writerName, List<VssWriterDescriptor> writerList)
+        {
+            Host.WriteLine("- Verifing that all components of writer \"{0}\" are included in backup...", writerName);
 
-      private void AddToSnapshotSet(IEnumerable<string> volumeList)
-      {
-         // Preserve the list of volumes for script generation 
-         m_latestVolumeList = new List<string>(volumeList);
-
-         // Add volumes to the shadow set 
-         foreach (string volume in volumeList)
-         {
-            Host.WriteLine("- Adding volume {0} [{1}] to the shadow set...", volume, Volume.GetDisplayNameForVolume(volume));
-            m_latestSnapshotIdList.Add(m_backupComponents.AddToSnapshotSet(volume));
-         }
-      }
-
-      private void SelectComponentsForBackup(IEnumerable<string> shadowSourceVolumes, IEnumerable<string> excludedWriterList, IEnumerable<string> includedWriterList)
-      {
-         // First, exclude all components that have data outside of the shadow set
-         DiscoverDirectlyExcludedComponents(excludedWriterList, m_writers);
-
-         // Then discover excluded components that have file groups outside the shadow set
-         DiscoverNonShadowedExcludedComponents(shadowSourceVolumes);
-
-         // Now, exclude all componenets that are have directly excluded descendents
-         DiscoverAllExcludedComponents();
-
-         // Next, exclude all writers that:
-         // - either have a top-level nonselectable excluded component
-         // - or do not have any included components (all its components are excluded)
-         DiscoverExcludedWriters();
-
-         // Now, discover the components that should be included (explicitly or implicitly)
-         // These are the top components that do not have any excluded children
-         DiscoverExplicitelyIncludedComponents();
-
-         Host.WriteLine("Verifying explicitly specified writers/components...");
-
-         foreach (string include in includedWriterList)
-         {
-            if (include.Contains(':'))
-               VerifyExplicitlyIncludedComponent(include, m_writers);
-            else
-               VerifyExplicitlyIncludedWriter(include, m_writers);
-         }
-
-         // Finally, select the explicitly included components
-         SelectExplicitelyIncludedComponents();
-      }
-
-      private void SelectExplicitelyIncludedComponents()
-      {
-         Host.WriteLine("Select explicitly included components ...");
-
-         foreach (VssWriterDescriptor writer in m_writers.Where(w => !w.IsExcluded))
-         {
-            Host.WriteLine(" * Writer '{0}':", writer.WriterMetadata.WriterName);
-
-            // Compute the roots of included components
-            foreach (var component in writer.ComponentDescriptors.Where(c => c.IsExplicitlyIncluded))
+            foreach (VssWriterDescriptor writer in writerList.Where(w => !w.IsExcluded))
             {
-               Host.WriteLine("    - Add component {0}", component.FullPath);
-               m_backupComponents.AddComponent(writer.WriterMetadata.InstanceId, writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName);
-            }
-         }
-      }
+                if (writerName.Equals(writer.WriterMetadata.WriterName) ||
+                   writerName.Equals(writer.WriterMetadata.WriterId.ToString("B"), StringComparison.OrdinalIgnoreCase) ||
+                   writerName.Equals(writer.WriterMetadata.InstanceId.ToString("B"), StringComparison.OrdinalIgnoreCase))
+                {
+                    if (writer.IsExcluded)
+                    {
+                        Host.WriteError("The writer \"{0}\" was not included in the backup! Aborting backup ...", writer.WriterMetadata.WriterName);
+                        Host.WriteError("- Please reveiw the component/subcomponent definitions");
+                        Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
+                        throw new CommandAbortedException();
+                    }
 
-      private void VerifyExplicitlyIncludedComponent(string include, List<VssWriterDescriptor> writerList)
-      {
-         Host.WriteLine("- Verifying component \"{0}\"...", include);
+                    if (writer.ComponentDescriptors.Any(component => component.IsExcluded))
+                    {
+                        Host.WriteError("ERROR: The writer \"{0}\" has components not included in the backup! Aborting backup ...", writer.WriterMetadata.WriterName);
+                        Host.WriteError("- Please reveiw the component/subcomponent definitions");
+                        Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
+                        throw new CommandAbortedException();
 
-         foreach (VssWriterDescriptor writer in writerList.Where(w => !w.IsExcluded))
-         {
-            // Find the associated component
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
-            {
-               if (include.Equals(writer.WriterMetadata.WriterName + ":" + component.FullPath) ||
-                   include.Equals(writer.WriterMetadata.WriterId.ToString("B") + ":" + component.FullPath, StringComparison.OrdinalIgnoreCase) ||
-                   include.Equals(writer.WriterMetadata.InstanceId.ToString("B") + ":" + component.FullPath, StringComparison.OrdinalIgnoreCase))
-               {
-                  Host.WriteVerbose("- Found component '{0}' from writer '{1}.", component.FullPath, writer.WriterMetadata.WriterName);
+                    }
 
-                  // If we are during restore, we just found our component
-                  if (m_duringRestore)
-                  {
-                     Host.WriteLine(" - The component \"{0}\" is selected.", include);
-                     return;
-                  }
-
-                  // If not explicitly included, check to see if there is an explicitly included ancestor
-                  bool isIncluded = component.IsExplicitlyIncluded;
-                  if (!isIncluded)
-                  {
-                     isIncluded = writer.ComponentDescriptors.Any(ancestor => ancestor.IsAncestorOf(component) && ancestor.IsExplicitlyIncluded);
-                  }
-
-                  if (isIncluded)
-                  {
-                     Host.WriteLine(" - The component \"{0}\" is selected.", include);
-                     return;
-                  }
-                  else
-                  {
-                     Host.WriteError("The component \"{0}\" was not included in the backup! Aborting backup...", include);
-                     Host.WriteError("- Please reveiw the component/subcomponent definitions");
-                     Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
-                     throw new CommandAbortedException();
-                  }
-               }
-            }
-         }
-
-         Host.WriteError("The component \"{0}\" was not found in the writer components list! Aborting backup ...", include);
-         Host.WriteError("- Please check the syntax of the component name.");
-         throw new CommandAbortedException();
-      }
-
-      private void VerifyExplicitlyIncludedWriter(string writerName, List<VssWriterDescriptor> writerList)
-      {
-         Host.WriteLine("- Verifing that all components of writer \"{0}\" are included in backup...", writerName);
-
-         foreach (VssWriterDescriptor writer in writerList.Where(w => !w.IsExcluded))
-         {
-            if (writerName.Equals(writer.WriterMetadata.WriterName) ||
-               writerName.Equals(writer.WriterMetadata.WriterId.ToString("B"), StringComparison.OrdinalIgnoreCase) ||
-               writerName.Equals(writer.WriterMetadata.InstanceId.ToString("B"), StringComparison.OrdinalIgnoreCase))
-            {
-               if (writer.IsExcluded)
-               {
-                  Host.WriteError("The writer \"{0}\" was not included in the backup! Aborting backup ...", writer.WriterMetadata.WriterName);
-                  Host.WriteError("- Please reveiw the component/subcomponent definitions");
-                  Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
-                  throw new CommandAbortedException();
-               }
-
-               if (writer.ComponentDescriptors.Any(component => component.IsExcluded))
-               {
-                  Host.WriteError("ERROR: The writer \"{0}\" has components not included in the backup! Aborting backup ...", writer.WriterMetadata.WriterName);
-                  Host.WriteError("- Please reveiw the component/subcomponent definitions");
-                  Host.WriteError("- Also, please verify list of volumes to be shadow copied.");
-                  throw new CommandAbortedException();
-
-               }
-
-               Host.WriteLine(" - All components from writer \"{0}\" are selected.", writerName);
-               return;
-            }
-         }
-
-         Host.WriteError("ERROR: The writer \"{0}\" was not found! Aborting backup ...", writerName);
-         Host.WriteError("- Please check the syntax of the writer name/id.");
-         throw new CommandAbortedException();
-      }
-
-      private void DiscoverExplicitelyIncludedComponents()
-      {
-         Host.WriteLine("Discover explicitly included components...");
-
-         // Enumerate all writers
-         foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
-         {
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => c.CanBeExplicitlyIncluded))
-            {
-               // Test if our component has a parent that is also included
-               // If so this cannot be explicitely included since we have another ancestor that that must be (implictely or explicitely) included
-               component.IsExplicitlyIncluded = !writer.ComponentDescriptors.Any(ancestor => ancestor.IsAncestorOf(component) && ancestor.CanBeExplicitlyIncluded);
-            }
-         }
-      }
-
-      private void DiscoverExcludedWriters()
-      {
-         Host.WriteLine("Discover excluded writers...");
-
-         // Enumerate writers
-         foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
-         {
-            // Discover if we have any:
-            // - non-excluded selectable components 
-            // - or non-excluded top-level non-selectable components
-            // If we have none, then the whole writer must be excluded from the backup
-            writer.IsExcluded = !writer.ComponentDescriptors.Any(comp => comp.CanBeExplicitlyIncluded);
-
-            // No included components were found
-            if (writer.IsExcluded)
-            {
-               Host.WriteLine("- The writer '{0} is now entierly excluded from the backup (it does not contain any components that can be potentially included in the backup).", writer.WriterMetadata.WriterName);
-               continue;
+                    Host.WriteLine(" - All components from writer \"{0}\" are selected.", writerName);
+                    return;
+                }
             }
 
-            // Now, discover if we have any top-level excluded non-selectable component 
-            // If this is true, then the whole writer must be excluded from the backup
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+            Host.WriteError("ERROR: The writer \"{0}\" was not found! Aborting backup ...", writerName);
+            Host.WriteError("- Please check the syntax of the writer name/id.");
+            throw new CommandAbortedException();
+        }
+
+        private void DiscoverExplicitelyIncludedComponents()
+        {
+            Host.WriteLine("Discover explicitly included components...");
+
+            // Enumerate all writers
+            foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
             {
-               if (component.IsTopLevel && !component.IsSelectable && component.IsExcluded)
-               {
-                  Host.WriteLine("- The writer '{0}' is now entierly excluded from the backup (the top-level non-selectable component '{1}' is an excluded component.",
-                     writer.WriterMetadata.WriterName, component.FullPath);
-                  writer.IsExcluded = true;
-                  break;
-               }
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => c.CanBeExplicitlyIncluded))
+                {
+                    // Test if our component has a parent that is also included
+                    // If so this cannot be explicitely included since we have another ancestor that that must be (implictely or explicitely) included
+                    component.IsExplicitlyIncluded = !writer.ComponentDescriptors.Any(ancestor => ancestor.IsAncestorOf(component) && ancestor.CanBeExplicitlyIncluded);
+                }
             }
-         }
-      }
+        }
 
-      private void DiscoverAllExcludedComponents()
-      {
-         Host.WriteLine("Discover all excluded components ...");
+        private void DiscoverExcludedWriters()
+        {
+            Host.WriteLine("Discover excluded writers...");
 
-         // Discover components that should be excluded from the shadow set 
-         // This means components that have at least one File Descriptor requiring 
-         // volumes not in the shadow set. 
-         foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
-         {
-            // Enumerate all components
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+            // Enumerate writers
+            foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
             {
-               // Check if this component has any excluded children
-               // If yes, deselect it
-               foreach (VssComponentDescriptor descendent in writer.ComponentDescriptors)
-               {
-                  if (component.IsAncestorOf(descendent) && descendent.IsExcluded)
-                  {
-                     Host.WriteLine("- Component '{0}' from writer '{1} is excluded from backup (it has an excluded descendent: '{2}').", component.FullPath, writer.WriterMetadata.WriterName, descendent.WriterName);
-                     component.IsExcluded = true;
-                     break;
-                  }
-               }
+                // Discover if we have any:
+                // - non-excluded selectable components 
+                // - or non-excluded top-level non-selectable components
+                // If we have none, then the whole writer must be excluded from the backup
+                writer.IsExcluded = !writer.ComponentDescriptors.Any(comp => comp.CanBeExplicitlyIncluded);
+
+                // No included components were found
+                if (writer.IsExcluded)
+                {
+                    Host.WriteLine("- The writer '{0} is now entierly excluded from the backup (it does not contain any components that can be potentially included in the backup).", writer.WriterMetadata.WriterName);
+                    continue;
+                }
+
+                // Now, discover if we have any top-level excluded non-selectable component 
+                // If this is true, then the whole writer must be excluded from the backup
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+                {
+                    if (component.IsTopLevel && !component.IsSelectable && component.IsExcluded)
+                    {
+                        Host.WriteLine("- The writer '{0}' is now entierly excluded from the backup (the top-level non-selectable component '{1}' is an excluded component.",
+                           writer.WriterMetadata.WriterName, component.FullPath);
+                        writer.IsExcluded = true;
+                        break;
+                    }
+                }
             }
-         }
-      }
+        }
 
-      private void DiscoverNonShadowedExcludedComponents(IEnumerable<string> shadowSourceVolumes)
-      {
-         Host.WriteLine("Discover components that reside outside the shadow set...");
+        private void DiscoverAllExcludedComponents()
+        {
+            Host.WriteLine("Discover all excluded components ...");
 
-         // Discover components that should be excluded from the shadow set 
-         // This means components that have at least one File Descriptor requiring 
-         // volumes not in the shadow set. 
-         foreach (VssWriterDescriptor writer in m_writers)
-         {
-            if (writer.IsExcluded)
-               continue;
-
-            // Check if the component is excluded
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+            // Discover components that should be excluded from the shadow set 
+            // This means components that have at least one File Descriptor requiring 
+            // volumes not in the shadow set. 
+            foreach (VssWriterDescriptor writer in m_writers.Where(w => w.IsExcluded == false))
             {
-               // Check to see if this component is explicitly excluded
-               if (component.IsExcluded)
-                  continue;
-
-               // Try to find an affected volume outside the shadow set
-               // If yes, exclude the component
-               for (int i = 0; i < component.AffectedVolumes.Count; i++)
-               {
-                  if (Volume.ClusterIsPathOnSharedVolume(Host, component.AffectedVolumes[i]))
-                  {
-                     component.AffectedVolumes[i] = Volume.ClusterGetVolumeNameForVolumeMountPoint(Host, component.AffectedVolumes[i]);
-                  }
-
-                  if (!shadowSourceVolumes.Contains(component.AffectedVolumes[i]))
-                  {
-                     string localVolume;
-                     try
-                     {
-                        localVolume = Volume.GetDisplayNameForVolume(component.AffectedVolumes[i]);
-                     }
-                     catch
-                     {
-                        localVolume = null;
-                     }
-
-                     if (localVolume != null)
-                     {
-                        Host.WriteLine("- Component '{0}' from writer '{1}' is excluded from backup (it requires {2} in the shadow set)",
-                           component.FullPath, writer.WriterMetadata.WriterName, localVolume);
-                     }
-                     else
-                     {
-                        Host.WriteLine("- Component '{0}' from writer '{1}' is excluded from backup.", component.FullPath, writer.WriterMetadata.WriterName);
-                     }
-                     component.IsExcluded = true;
-                     break;
-                  }
-               }
+                // Enumerate all components
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+                {
+                    // Check if this component has any excluded children
+                    // If yes, deselect it
+                    foreach (VssComponentDescriptor descendent in writer.ComponentDescriptors)
+                    {
+                        if (component.IsAncestorOf(descendent) && descendent.IsExcluded)
+                        {
+                            Host.WriteLine("- Component '{0}' from writer '{1} is excluded from backup (it has an excluded descendent: '{2}').", component.FullPath, writer.WriterMetadata.WriterName, descendent.WriterName);
+                            component.IsExcluded = true;
+                            break;
+                        }
+                    }
+                }
             }
-         }
-
-
-
-
-      }
-
-      private void DiscoverDirectlyExcludedComponents(IEnumerable<string> excludedWriterAndComponentList, List<VssWriterDescriptor> writerList)
-      {
-         Host.WriteLine("Discover directly excluded components...");
-
-         // Discover components that should be excluded from the shadow set 
-         // This means components that have at least one File Descriptor requiring 
-         // volumes not in the shadow set. 
-         foreach (var writer in writerList)
-         {
-            // Check if the writer is excluded
-            if (excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterName) ||
-                excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterId.ToString("B"), StringComparer.OrdinalIgnoreCase) ||
-                excludedWriterAndComponentList.Contains(writer.WriterMetadata.InstanceId.ToString("B"), StringComparer.OrdinalIgnoreCase))
-            {
-               writer.IsExcluded = true;
-               continue;
-            }
-
-            // Check if the component is excluded
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
-            {
-               // Check to see if this component is explicitly excluded
-               if (excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterName + ":" + component.FullPath) ||
-                   excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterId + ":" + component.FullPath) ||
-                  excludedWriterAndComponentList.Contains(writer.WriterMetadata.InstanceId + ":" + component.FullPath))
-               {
-                  Host.WriteLine("- Component '{0}' from writer '{1}' is explicitly excluded from backup.", component.FullPath, writer.WriterMetadata.WriterName);
-                  component.IsExcluded = true;
-                  continue;
-               }
-            }
-
-            // If there are no included components, exclude the writer.
-            if (!writer.ComponentDescriptors.Any(comp => comp.IsExcluded == false))
-            {
-               Host.WriteLine("- Excluding writer '{0}' since it has no selected components for restore.", writer.WriterMetadata.WriterName);
-               writer.IsExcluded = true;
-            }
-         }
-      }
-
-      public void GatherWriterMetadata()
-      {
-         Host.WriteLine("Gathering writer metadata...");
-
-         // Gathers writer metadata
-         // WARNING: this call can be performed only once per IVssBackupComponents instance!
-
-         using (IVssAsyncResult result = m_backupComponents.BeginGatherWriterMetadata(null, null))
-         {
-            Host.WriteLine("Waiting for asynchronous operation to complete...");
-            result.AsyncWaitHandle.WaitOne();
-         }
-
-         Host.WriteLine("- Initialize writer metadata...");
-         InitializeWriterMetadata();
-      }
-
-      internal void GatherWriterMetadataToScreen()
-      {
-         Host.WriteLine("Gathering writer metadata...");
-
-         using (IVssAsyncResult result = m_backupComponents.BeginGatherWriterMetadata(null, null))
-         {
-            Host.WriteLine("Waiting for asynchronous operation to complete...");
-            result.AsyncWaitHandle.WaitOne();
-         }
-
-         int c = 1;
-         foreach (IVssExamineWriterMetadata writerMetadata in m_backupComponents.WriterMetadata)
-         {
-            string xml = writerMetadata.SaveAsXml();
-            Host.WriteHeader("[Writer {0}]", c++);
-            Host.WriteLine("{0}", xml);
-         }
-
-         Host.WriteHeader("[End of data]");
-      }
-
-      public void GatherWriterStatus()
-      {
-         Host.WriteLine("Gather writer status...");
-         m_backupComponents.GatherWriterStatus();
-      }
-
-      public void ListWriterStatus()
-      {
-         Host.WriteLine("Listing writer status...");
-
-         using (var i1 = Host.GetIndent())
-         {
-            IList<VssWriterStatusInfo> statusList = m_backupComponents.WriterStatus;
-            Host.WriteLine("Number of writers that responded: {0}", statusList.Count);
-
-            using (var i2 = Host.GetIndent())
-            {
-               foreach (VssWriterStatusInfo info in statusList)
-               {
-                  Host.WriteLine();
-                  Host.WriteHeader("Writer \"{0}\"", info.Name);
-
-                  StringTable table = new StringTable();
-                  table.Add("Status:", info.State);
-                  table.Add("Writer failure code:", info.Failure);
-                  table.Add("Writer ID:", info.ClassId.ToString("B"));
-                  table.Add("Instance ID:", info.InstanceId.ToString("B"));
-
-                  Host.WriteTable(table, 3);
-               }
-            }
-         }
-      }
-
-      private void InitializeWriterMetadata()
-      {
-         m_writers = new List<VssWriterDescriptor>(m_backupComponents.WriterMetadata.Select(wm => new VssWriterDescriptor(Host, wm)));         
-      }
-      #endregion
-
-      #region Private Methods
-
-      private void PrintSnapshotProperties(VssSnapshotProperties props)
-      {
-         StringTable table = new StringTable();
-
-         Host.WriteLine();
-         Host.WriteHeader("SNAPSHOT ID = {0:B}", props.SnapshotId);
-
-         table.Add("Shadow Copy Set ID:", props.SnapshotSetId.ToString("B"));
-         table.Add("Original Shadow Copy Count:", props.SnapshotsCount);
-         table.Add("Original Volume Name:", props.OriginalVolumeName);
-         table.Add("Creation Time:", props.CreationTimestamp);
-         table.Add("Device Name:", props.SnapshotDeviceObject);
-         table.Add("Originating Machine:", props.OriginatingMachine);
-         table.Add("Service Machine:", props.ServiceMachine);
-
-         if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ExposedLocally) != 0)
-            table.Add("Exposed Locally as:", props.ExposedName);
-         else if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ExposedRemotely) != 0)
-         {
-            table.Add("Exposed Remotely as:", props.ExposedName);
-            if (!String.IsNullOrEmpty(props.ExposedPath))
-               table.Add("Path Exposed:", props.ExposedPath);
-         }
-         else
-         {
-            table.Add("Is Exposed:", "No");
-         }
-
-         table.Add("Provider ID:", props.ProviderId.ToString("B"));
-
-         StringBuilder attributes = new StringBuilder();
-         foreach (VssVolumeSnapshotAttributes value in Enum.GetValues(typeof(VssVolumeSnapshotAttributes)))
-         {
-            if (value != VssVolumeSnapshotAttributes.ExposedLocally && value != VssVolumeSnapshotAttributes.ExposedRemotely
-               && (props.SnapshotAttributes & value) == value)
-            {
-               attributes.AppendFormat("{0} ", value);
-            }
-         }
-         table.Add("Snapshot Attributes:", attributes.ToString());
-
-         Host.WriteTable(table, 2);
-
-      }
-
-      #endregion
-
-
-      #region IDisposable Members
-
-      public void Dispose()
-      {
-         if (m_backupComponents != null)
-         {
-            m_backupComponents.Dispose();
-            m_backupComponents = null;
-         }
-      }
-
-      #endregion
-
-      internal void ListWriterMetadata(bool detailed)
-      {
-         Host.WriteLine("Listing writer metadata...");
-
-         foreach (VssWriterDescriptor writer in m_writers)
-         {
-            Host.WriteLine();
-
-            // Print writer identity information
-            Host.WriteHeader("Writer \"{0}\"", writer.WriterMetadata.WriterName);
-            Host.PushIndent();
-            StringTable table = new StringTable();
-            table.Add("Writer ID:", writer.WriterMetadata.WriterId.ToString("B"));
-            table.Add("Instance ID:", writer.WriterMetadata.InstanceId.ToString("B"));
-            if (writer.WriterMetadata.RestoreMethod == null)
-            {
-               table.Add("Restore Method:", "No restore method specified by this writer.");
-            }
-            else
-            {
-               table.Add("Supports restore events:", (writer.WriterMetadata.RestoreMethod.WriterRestore != VssWriterRestore.Never).ToString());
-               table.Add("Writer restore conditions:", writer.WriterMetadata.RestoreMethod.Method);
-               table.Add("Requires reboot after restore:", writer.WriterMetadata.RestoreMethod.RebootRequired);
-            }
-            if (!writer.WriterMetadata.ExcludeFiles.Any())
-               table.Add("Excluded files:", "<none>");
-            else
-               table.Add("Excluded files:", "");
-
-            Host.WriteTable(table);
-
-            foreach (VssWMFileDescriptor file in writer.WriterMetadata.ExcludeFiles)
-            {
-               PrintFileDescription(file);
-               Host.WriteLine();
-            }
-
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
-            {
-               PrintComponent(component, detailed);
-               Host.WriteLine();
-            }
-
-            Host.PopIndent();
-         }
-      }
-
-      private void PrintComponent(VssComponentDescriptor component, bool detailed)
-      {
-         Host.WriteHeader("Component \"{0}:{1}\"", component.WriterName, component.FullPath);
-         Host.PushIndent();
-         StringTable table = new StringTable();
-         table.Add("Name:", component.ComponentName);
-         table.Add("Logical Path:", component.LogicalPath);
-         table.Add("Full Path:", component.FullPath);
-         table.Add("Caption: ", component.Caption);
-         table.Add("Type:", component.ComponentType);
-         table.Add("Is Selectable:", component.IsSelectable);
-         table.Add("Is Top Level:", component.IsTopLevel);
-         table.Add("Notify on backup complete:", component.NotifyOnBackupComplete);
-         Host.WriteTable(table);
-
-         if (detailed)
-         {
-            Host.WriteLine("Components:");
-            Host.PushIndent();
-            foreach (VssWMFileDescriptor file in component.Files)
-            {
-               PrintFileDescription(file, "File");
-               Host.WriteLine();
-            }
-
-            foreach (VssWMFileDescriptor file in component.DatabaseFiles)
-            {
-               PrintFileDescription(file, "Database");
-               Host.WriteLine();
-            }
-
-            foreach (VssWMFileDescriptor file in component.DatabaseLogFiles)
-            {
-               PrintFileDescription(file, "Database Log File");
-               Host.WriteLine();
-            }
-
-            Host.PopIndent();
-         }
-
-         Host.WriteLine("Paths affected by this component:");
-         Host.PushIndent();
-         foreach (string path in component.AffectedPaths)
-            Host.WriteLine("{0}", path);
-         Host.PopIndent();
-
-         Host.WriteLine("Volumes affected by this component:");
-         Host.PushIndent();
-         foreach (string volume in component.AffectedVolumes)
-         {
-            string displayName;
-            try
-            {
-               displayName = Volume.GetDisplayNameForVolume(volume);
-            }
-            catch
-            {
-               displayName = "Not valid for local machine";
-            }
-            Host.WriteLine("{0} [{1}]", volume, displayName);
-         }
-         Host.PopIndent();
-
-         if (component.Dependencies.Any())
-         {
-            Host.WriteLine("Component Dependencies:");
-            Host.PushIndent();
-            foreach (var dependency in component.Dependencies)
-               PrintDependency(dependency);
-            Host.PopIndent();
-         }
-
-         Host.PopIndent();
-
-      }
-
-      private void PrintDependency(VssWMDependency dependency)
-      {
-         Host.WriteLine("Dependency to \"{0}:{1}\"", dependency.ComponentName, dependency.LogicalPath);
-      }
-
-      private void PrintFileDescription(VssWMFileDescriptor file, string type = null)
-      {
-         string alternateDisplayPath = "";
-         if (!String.IsNullOrEmpty(file.AlternateLocation))
-            alternateDisplayPath = String.Format(", Alternate Location={0}" + file.AlternateLocation);
-
-         Host.PushIndent();
-         StringTable table = new StringTable();
-         if (type != null)
-            table.Add("Type:", type);
-         table.Add("Path:", file.Path);
-         table.Add("Filespec:", file.FileSpecification);
-         table.Add("Recursive:", file.IsRecursive);
-         if (!String.IsNullOrEmpty(file.AlternateLocation))
-            table.Add("Alternate Location:", file.AlternateLocation);
-
-         Host.WriteTable(table);
-         Host.PopIndent();
-      }
-
-      internal void GenerateSetvarScript(string fileName)
-      {
-         Host.WriteLine("Generating the SETVAR script ({0})... ", fileName);
-
-         using (StreamWriter writer = new StreamWriter(fileName))
-         {
-            writer.WriteLine("@echo.");
-            writer.WriteLine("@echo [This script is generated by AlphaShadow.exe for the shadow set {0:B}]", m_latestSnapshotSetId);
-            writer.WriteLine("@echo.");
-            writer.WriteLine();
-
-            writer.WriteLine("SET SHADOW_SET_ID={0:B}", m_latestSnapshotSetId);
-
-            // For each added volume add the AlphaShadow.exe exposure command
-            for (int i = 0; i < m_latestSnapshotIdList.Count; i++)
-            {
-               Guid snapshotId = m_latestSnapshotIdList[i];
-               writer.WriteLine("SET SHADOW_ID_{0}={1:B}", i, snapshotId);
-               if ((m_context & VssVolumeSnapshotAttributes.Transportable) == 0)
-               {
-                  VssSnapshotProperties properties = m_backupComponents.GetSnapshotProperties(snapshotId);
-                  writer.WriteLine("SET SHADOW_DEVICE_{0}={1}", i, properties.SnapshotDeviceObject);
-               }
-            }
-         }
-      }
-
-      internal void BackupComplete(bool succeeded)
-      {
-         if (m_backupComponents.WriterComponents.Count == 0)
-         {
-            Host.WriteLine("- There were no writer components in this backup");
-            return;
-         }
-         else if (succeeded)
-         {
-            Host.WriteLine("- Mark all writers as successfully backed up...");
-         }
-         else
-         {
-            Host.WriteLine("- Backup failed. Mark all writers as not successfully backed up...");
-         }
-
-         SetBackupSucceeded(succeeded);
-
-         Host.WriteLine("Completing the backup (BackupComplete) ... ");
-
-         m_backupComponents.BackupComplete();
-
-         // Check selected writer status
-         CheckSelectedWriterStatus();
-
-      }
-
-      private void SetBackupSucceeded(bool succeeded)
-      {
-         foreach (VssWriterDescriptor writer in m_writers)
-         {
-            foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => c.IsExplicitlyIncluded))
-            {
-               m_backupComponents.SetBackupSucceeded(writer.WriterMetadata.InstanceId,
-                  writer.WriterMetadata.WriterId,
-                  component.ComponentType,
-                  component.LogicalPath,
-                  component.ComponentName,
-                  succeeded);
-            }
-         }
-      }
-
-      internal void DeleteSnapshot(Guid snapshotId)
-      {
-         Host.WriteLine("- Deleting shadow copy {0:B}...", snapshotId);
-
-         m_backupComponents.DeleteSnapshot(snapshotId, false);
-      }
-
-      internal void DeleteSnapshotSet(Guid snapshotSetId)
-      {
-         Host.WriteLine("- Deleting shadow copy set {0:B}...", snapshotSetId);
-
-         int deletedSnapshots = m_backupComponents.DeleteSnapshotSet(snapshotSetId, false);
-
-         Host.WriteLine("{0} snapshots were successfully deleted.", deletedSnapshots);
-      }
-
-      internal void DeleteAllSnapshots()
-      {
-         // Get a list of all shadow copies
-         IList<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots().ToArray();
-
-         if (snapshots.Count == 0)
-         {
-            Host.WriteLine("There were no shadow copies on the system.");
-            return;
-         }
-
-         Host.PushIndent();
-         try
-         {
-            foreach (VssSnapshotProperties snapshot in snapshots)
-            {
-               Host.WriteLine("- Deleting shadow copy {0:B} on {1} from provider {2} [{3}]...", snapshot.SnapshotId, snapshot.OriginalVolumeName, snapshot.ProviderId, snapshot.SnapshotAttributes);
-               m_backupComponents.DeleteSnapshot(snapshot.SnapshotId, false);
-            }
-         }
-         finally
-         {
-            Host.PopIndent();
-         }
-      }
-
-      internal void DeleteOldestSnapshot(string volume)
-      {
-         string uniqueVolume = Volume.GetUniqueVolumeNameForPath(Host, volume, false);
-         IList<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots().ToArray();
-
-         if (snapshots.Count == 0)
-         {
-            Host.WriteLine("There are now shadow copies in the system.");
-            return;
-         }
-
-         VssSnapshotProperties snapshot = snapshots
-            .Where(snap => snap.OriginalVolumeName.Equals(uniqueVolume, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(snap => snap.CreationTimestamp).FirstOrDefault();
-
-         if (snapshot == null)
-         {
-            Host.WriteLine("There are no shadow copies for the specified volume in the system.");
-            return;
-         }
-
-         Host.WriteLine("- Deleting shadow copy {0:B} on {1} from provider {2} [{3}]...", snapshot.SnapshotId, snapshot.OriginalVolumeName, snapshot.ProviderId, snapshot.SnapshotAttributes);
-         m_backupComponents.DeleteSnapshot(snapshot.SnapshotId, false);
-      }
-
-      internal void RevertToSnapshot(Guid snapshotId)
-      {
-         VssSnapshotProperties snapshot = m_backupComponents.GetSnapshotProperties(snapshotId);
-
-         Host.WriteLine("Reverting to shadow copy {0:B} on {1} from provider {2:B} [{3}]...",
-            snapshot.SnapshotId,
-            snapshot.OriginalVolumeName,
-            snapshot.ProviderId,
-            snapshot.SnapshotAttributes);
-
-         if (s_implementation.ShouldBlockRevert(snapshot.OriginalVolumeName))
-         {
-            Host.WriteWarning("Revert is disabled on the volume {0} because of writers.", snapshot.OriginalVolumeName);
-            return;
-         }
-
-         m_backupComponents.RevertToSnapshot(snapshot.SnapshotId, true);
-
-         IVssAsyncResult ar = m_backupComponents.BeginQueryRevertStatus(snapshot.OriginalVolumeName, null, null);
-         m_backupComponents.EndQueryRevertStatus(ar);
-
-         Host.WriteLine("The shadow copy has been successfully reverted.");
-      }
-
-      // Return the list of snapshot volume devices in this snapshot set
-      private IList<string> GetSnapshotDevices(Guid snapshotSetID)
-      {
-         List<string> volumes = new List<string>();
-         foreach (VssSnapshotProperties snapshot in m_backupComponents.QuerySnapshots().Where(snap => snap.SnapshotSetId == snapshotSetID))
-         {
-            // Get the snapshot device object name which is a volume guid name for persistent snapshot
-            // and a device name for non persistent snapshot.
-            // The volume guid name and the device name we obtained here might change after breaksnapshot
-            // depending on if the disk signature is reverted, but those cached names should still work
-            // as symbolic links, in which case they can not persist after reboot.
-            Host.WriteLine("Will convert {0} to read-write...", snapshot.SnapshotDeviceObject);
-            volumes.Add(snapshot.SnapshotDeviceObject);
-         }
-
-         return volumes;
-      }
-
-
-      internal void ExposeShapshotLocally(Guid snapshotId, string path)
-      {
-         Host.WriteLine("Exposing shadow copy {0:B} under the path '{1}'", snapshotId, path);
-
-         VerifyExposeSnapshot(snapshotId);
-
-         // Check if the path parameter is valid
-         if (path.Length == 2 && path.EndsWith(":"))
-         {
-            Host.WriteLine("Checking if '{0}' is a valid drive letter...", path);
-
-            try
-            {
-               Volume.QueryDosDevice(path);
-               throw new ArgumentException(String.Format("The specified mount point [{0}] is a drive letter already in use.", path));
-            }
-            catch (Win32Exception ex)
-            {
-               if (ex.NativeErrorCode != 2)
-                  throw;
-            }
-               
-         }
-         else
-         {
-            path = path.AppendBackslash();
-
-            Host.WriteLine("Checking if '{0} is a valid empty directory...", path);
-
-            if (!Directory.Exists(path))
-               throw new ArgumentException(String.Format("The specified mount point [{0}] is not a valid directory.", path));
-
-            if (Directory.GetFileSystemEntries(path).Any())
-               throw new ArgumentException(String.Format("The specified mount point [{0}] is not an empty directory.", path));
-
-         }
-         // Expose the snapshot locally 
-         m_backupComponents.ExposeSnapshot(snapshotId, null, VssVolumeSnapshotAttributes.ExposedLocally, path);
-
-         Host.WriteLine("Shadow copy exposed as '{0}'", path);
-      }
-
-      private void VerifyExposeSnapshot(Guid snapshotId)
-      {
-         // Make sure that the expose operation is valid for this snapshot.
-         // Get the shadow copy properties
-         VssSnapshotProperties props;
-         try
-         {
-            props = m_backupComponents.GetSnapshotProperties(snapshotId);
-         }
-         catch (VssObjectNotFoundException)
-         {
-            throw new ArgumentException("There is no snapshot with the given id.");
-         }
-
-         // Client Accessible snapshots are not exposable
-         if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ClientAccessible) != 0)
-            throw new ArgumentException("The snapshot id identifies a client accessible snapshot which cannot be exposed.");
-
-         if (!String.IsNullOrEmpty(props.ExposedName) || !String.IsNullOrEmpty(props.ExposedPath))
-            throw new ArgumentException("Client-accessible (SFSF) snapshots cannot be exposed.");
-      }
-
-      internal void ExposeSnapshotRemotely(Guid snapshotId, string shareName, string pathFromRoot)
-      {
-         pathFromRoot = String.IsNullOrEmpty(pathFromRoot) ? null : pathFromRoot;
-
-         Host.WriteLine("Exposing shadow copy {0:B} under the share '{1}' (path from root: '{2}')", snapshotId, shareName, pathFromRoot ?? "");
-
-         VerifyExposeSnapshot(snapshotId);
-
-         // Note: a true reqester should also check here if 
-         // - the remote share name is valid (i.e. unused)
-         // - the path from root is valid
-         m_backupComponents.ExposeSnapshot(snapshotId, pathFromRoot, VssVolumeSnapshotAttributes.ExposedRemotely, shareName);
-      }
-
-      internal void ImportSnapshotSet()
-      {
-         Host.WriteLine("Importing the transportable shadow copy...");
-
-         m_backupComponents.ImportSnapshots();
-
-         Host.WriteLine("Shadow copy set successfully imported.");
-      }
-
-      internal void InitializeWriterComponentsForRestore()
-      {
-         Host.WriteLine("Initializing writer components for restore...");
-
-         m_writerComponentsForRestore = new List<VssWriterDescriptor>();
-
-         bool found = false;
-         // Enumerate the list of writers in the metadata  
-         foreach (IVssWriterComponents components in m_backupComponents.WriterComponents)
-         {
-            // Try to discover the name based on an existing writer (identical ID and instance ID).
-            // Otherwise, ignore it!
+        }
+
+        private void DiscoverNonShadowedExcludedComponents(IEnumerable<string> shadowSourceVolumes)
+        {
+            Host.WriteLine("Discover components that reside outside the shadow set...");
+
+            // Discover components that should be excluded from the shadow set 
+            // This means components that have at least one File Descriptor requiring 
+            // volumes not in the shadow set. 
             foreach (VssWriterDescriptor writer in m_writers)
             {
-               // Do not check for instance id.
-               if (components.WriterId != writer.WriterMetadata.WriterId)
-                  continue;
+                if (writer.IsExcluded)
+                    continue;
 
-               Host.WriteLine("Writer {0} is present in the Backup Components document and on the system. Considering for restore...", writer.WriterMetadata.WriterName);
+                // Check if the component is excluded
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+                {
+                    // Check to see if this component is explicitly excluded
+                    if (component.IsExcluded)
+                        continue;
 
-               // Adding components
-               writer.InitializeComponentsForRestore(components);
+                    // Try to find an affected volume outside the shadow set
+                    // If yes, exclude the component
+                    for (int i = 0; i < component.AffectedVolumes.Count; i++)
+                    {
+                        if (Volume.ClusterIsPathOnSharedVolume(Host, component.AffectedVolumes[i]))
+                        {
+                            component.AffectedVolumes[i] = Volume.ClusterGetVolumeNameForVolumeMountPoint(Host, component.AffectedVolumes[i]);
+                        }
 
-               m_writerComponentsForRestore.Add(writer);
+                        if (!shadowSourceVolumes.Contains(component.AffectedVolumes[i]))
+                        {
+                            string localVolume;
+                            try
+                            {
+                                localVolume = Volume.GetDisplayNameForVolume(component.AffectedVolumes[i]);
+                            }
+                            catch
+                            {
+                                localVolume = null;
+                            }
 
-               found = true;
+                            if (localVolume != null)
+                            {
+                                Host.WriteLine("- Component '{0}' from writer '{1}' is excluded from backup (it requires {2} in the shadow set)",
+                                   component.FullPath, writer.WriterMetadata.WriterName, localVolume);
+                            }
+                            else
+                            {
+                                Host.WriteLine("- Component '{0}' from writer '{1}' is excluded from backup.", component.FullPath, writer.WriterMetadata.WriterName);
+                            }
+                            component.IsExcluded = true;
+                            break;
+                        }
+                    }
+                }
             }
 
-            if (!found)
+
+
+
+        }
+
+        private void DiscoverDirectlyExcludedComponents(IEnumerable<string> excludedWriterAndComponentList, List<VssWriterDescriptor> writerList)
+        {
+            Host.WriteLine("Discover directly excluded components...");
+
+            // Discover components that should be excluded from the shadow set 
+            // This means components that have at least one File Descriptor requiring 
+            // volumes not in the shadow set. 
+            foreach (var writer in writerList)
             {
-               Host.WriteLine("Writer with ID {0:B} is not present in the system. Ignoring...", components.WriterId);
+                // Check if the writer is excluded
+                if (excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterName) ||
+                    excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterId.ToString("B"), StringComparer.OrdinalIgnoreCase) ||
+                    excludedWriterAndComponentList.Contains(writer.WriterMetadata.InstanceId.ToString("B"), StringComparer.OrdinalIgnoreCase))
+                {
+                    writer.IsExcluded = true;
+                    continue;
+                }
+
+                // Check if the component is excluded
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+                {
+                    // Check to see if this component is explicitly excluded
+                    if (excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterName + ":" + component.FullPath) ||
+                        excludedWriterAndComponentList.Contains(writer.WriterMetadata.WriterId + ":" + component.FullPath) ||
+                       excludedWriterAndComponentList.Contains(writer.WriterMetadata.InstanceId + ":" + component.FullPath))
+                    {
+                        Host.WriteLine("- Component '{0}' from writer '{1}' is explicitly excluded from backup.", component.FullPath, writer.WriterMetadata.WriterName);
+                        component.IsExcluded = true;
+                        continue;
+                    }
+                }
+
+                // If there are no included components, exclude the writer.
+                if (!writer.ComponentDescriptors.Any(comp => comp.IsExcluded == false))
+                {
+                    Host.WriteLine("- Excluding writer '{0}' since it has no selected components for restore.", writer.WriterMetadata.WriterName);
+                    writer.IsExcluded = true;
+                }
             }
-         }
-      }
+        }
 
-      internal void SelectComponentsForRestore(IList<string> excludedWriterAndComponentList, IList<string> includedWriterAndComponentList)
-      {
-         // First, exclude all components that have data outside of the shadow set
-         DiscoverDirectlyExcludedComponents(excludedWriterAndComponentList, m_writerComponentsForRestore);
+        public void GatherWriterMetadata()
+        {
+            Host.WriteLine("Gathering writer metadata...");
 
-         // Exclude all writers that do not support restore events
-         ExcludeWritersWithNoRestoreEvents();
+            // Gathers writer metadata
+            // WARNING: this call can be performed only once per IVssBackupComponents instance!
 
-         Host.WriteLine("Verifying explicitly specified writers/components...");
+            using (IVssAsyncResult result = m_backupComponents.BeginGatherWriterMetadata(null, null))
+            {
+                Host.WriteLine("Waiting for asynchronous operation to complete...");
+                result.AsyncWaitHandle.WaitOne();
+            }
 
-         foreach (string inc in includedWriterAndComponentList)
-         {
-            if (inc.Contains(':'))
-               VerifyExplicitlyIncludedComponent(inc, m_writerComponentsForRestore);
+            GatherWriterMetadata_After();
+        }
+
+        public async Task GatherWriterMetadataAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Gathering writer metadata...");
+
+            // Gathers writer metadata
+            // WARNING: this call can be performed only once per IVssBackupComponents instance!
+
+            await m_backupComponents.GatherWriterMetadataAsync(cancellationToken);
+
+            GatherWriterMetadata_After();
+        }
+
+        private void GatherWriterMetadata_After()
+        {
+            Host.WriteLine("- Initialize writer metadata...");
+            InitializeWriterMetadata();
+        }
+
+        internal void GatherWriterMetadataToScreen()
+        {
+            Host.WriteLine("Gathering writer metadata...");
+
+            using (IVssAsyncResult result = m_backupComponents.BeginGatherWriterMetadata(null, null))
+            {
+                Host.WriteLine("Waiting for asynchronous operation to complete...");
+                result.AsyncWaitHandle.WaitOne();
+            }
+
+            GatherWriterMetadataToScreen_After();
+        }
+
+        internal async Task GatherWriterMetadataToScreenAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Gathering writer metadata...");
+
+            await m_backupComponents.GatherWriterMetadataAsync(cancellationToken);
+
+            GatherWriterMetadataToScreen_After();
+        }
+
+        private void GatherWriterMetadataToScreen_After()
+        {
+            int c = 1;
+            foreach (IVssExamineWriterMetadata writerMetadata in m_backupComponents.WriterMetadata)
+            {
+                string xml = writerMetadata.SaveAsXml();
+                Host.WriteHeader("[Writer {0}]", c++);
+                Host.WriteLine("{0}", xml);
+            }
+
+            Host.WriteHeader("[End of data]");
+        }
+
+        public void GatherWriterStatus()
+        {
+            Host.WriteLine("Gather writer status...");
+            m_backupComponents.GatherWriterStatus();
+        }
+
+        public Task GatherWriterStatusAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Gather writer status...");
+            return m_backupComponents.GatherWriterStatusAsync(cancellationToken);
+        }
+
+        public void ListWriterStatus()
+        {
+            Host.WriteLine("Listing writer status...");
+
+            using (var i1 = Host.GetIndent())
+            {
+                IList<VssWriterStatusInfo> statusList = m_backupComponents.WriterStatus;
+                Host.WriteLine("Number of writers that responded: {0}", statusList.Count);
+
+                using (var i2 = Host.GetIndent())
+                {
+                    foreach (VssWriterStatusInfo info in statusList)
+                    {
+                        Host.WriteLine();
+                        Host.WriteHeader("Writer \"{0}\"", info.Name);
+
+                        StringTable table = new StringTable();
+                        table.Add("Status:", info.State);
+                        table.Add("Writer failure code:", info.Failure);
+                        table.Add("Writer ID:", info.ClassId.ToString("B"));
+                        table.Add("Instance ID:", info.InstanceId.ToString("B"));
+
+                        Host.WriteTable(table, 3);
+                    }
+                }
+            }
+        }
+
+        private void InitializeWriterMetadata()
+        {
+            m_writers = new List<VssWriterDescriptor>(m_backupComponents.WriterMetadata.Select(wm => new VssWriterDescriptor(Host, wm)));
+        }
+        #endregion
+
+        #region Private Methods
+
+        private void PrintSnapshotProperties(VssSnapshotProperties props)
+        {
+            StringTable table = new StringTable();
+
+            Host.WriteLine();
+            Host.WriteHeader("SNAPSHOT ID = {0:B}", props.SnapshotId);
+
+            table.Add("Shadow Copy Set ID:", props.SnapshotSetId.ToString("B"));
+            table.Add("Original Shadow Copy Count:", props.SnapshotsCount);
+            table.Add("Original Volume Name:", props.OriginalVolumeName);
+            table.Add("Creation Time:", props.CreationTimestamp);
+            table.Add("Device Name:", props.SnapshotDeviceObject);
+            table.Add("Originating Machine:", props.OriginatingMachine);
+            table.Add("Service Machine:", props.ServiceMachine);
+
+            if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ExposedLocally) != 0)
+                table.Add("Exposed Locally as:", props.ExposedName);
+            else if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ExposedRemotely) != 0)
+            {
+                table.Add("Exposed Remotely as:", props.ExposedName);
+                if (!String.IsNullOrEmpty(props.ExposedPath))
+                    table.Add("Path Exposed:", props.ExposedPath);
+            }
             else
-               VerifyExplicitlyIncludedWriter(inc, m_writerComponentsForRestore);
-         }
-
-         // Finally, select the explicitly included components
-         SelectNonexcludedComponentsForRestore();
-      }
-
-      private void SelectNonexcludedComponentsForRestore()
-      {
-         Host.WriteLine("Select components for restore...");
-
-         Host.PushIndent();
-         try
-         {
-            foreach (VssWriterDescriptor writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
             {
-               Host.WriteLine("* Writer '{0}':", writer.WriterMetadata.WriterName);
-
-               Host.PushIndent();
-               try
-               {
-                  // Compute the roots of included components
-                  foreach (var component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
-                  {
-                     Host.WriteLine("- Select component {0}", component.FullPath);
-                     m_backupComponents.SetSelectedForRestore(writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName, true);
-                  }
-               }
-               finally
-               {
-                  Host.PopIndent();
-               }
+                table.Add("Is Exposed:", "No");
             }
-         }
-         finally
-         {
-            Host.PopIndent();
-         }
-      }
 
-      private void ExcludeWritersWithNoRestoreEvents()
-      {
-         Host.WriteLine("Exclude writers that do not support restore events...");
+            table.Add("Provider ID:", props.ProviderId.ToString("B"));
 
-
-         foreach (var writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
-         {
-            if (writer.WriterMetadata.RestoreMethod.WriterRestore == VssWriterRestore.Never)
+            StringBuilder attributes = new StringBuilder();
+            foreach (VssVolumeSnapshotAttributes value in Enum.GetValues(typeof(VssVolumeSnapshotAttributes)))
             {
-               Host.WriteLine("Excluding writer '{0}' since it does not support restore events.", writer.WriterMetadata.WriterName);
-               writer.IsExcluded = true;
+                if (value != VssVolumeSnapshotAttributes.ExposedLocally && value != VssVolumeSnapshotAttributes.ExposedRemotely
+                   && (props.SnapshotAttributes & value) == value)
+                {
+                    attributes.AppendFormat("{0} ", value);
+                }
             }
-         }
-      }
+            table.Add("Snapshot Attributes:", attributes.ToString());
 
-      internal void PreRestore()
-      {
-         Host.WriteLine("Sending the PreRestore event...");
-         m_backupComponents.PreRestore();
-      }
+            Host.WriteTable(table, 2);
 
-      internal void SetFileRestoreStatus(bool successfullyRestored)
-      {
-         Host.WriteLine("Set restore status for all components for restore...");
+        }
 
-         // All-or-nothing policy
-         //
-         // WARNING: this might be insufficient since we cannot distinguish
-         // between a partial failed restore and a completely failed restore!
-         // A true requester should be able to make this difference (see the documentation for more details)
-         VssFileRestoreStatus restoreStatus = successfullyRestored ? VssFileRestoreStatus.All : VssFileRestoreStatus.None;
+        #endregion
 
-         try
-         {
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            if (m_backupComponents != null)
+            {
+                m_backupComponents.Dispose();
+                m_backupComponents = null;
+            }
+        }
+
+        #endregion
+
+        internal void ListWriterMetadata(bool detailed)
+        {
+            Host.WriteLine("Listing writer metadata...");
+
+            foreach (VssWriterDescriptor writer in m_writers)
+            {
+                Host.WriteLine();
+
+                // Print writer identity information
+                Host.WriteHeader("Writer \"{0}\"", writer.WriterMetadata.WriterName);
+                Host.PushIndent();
+                StringTable table = new StringTable();
+                table.Add("Writer ID:", writer.WriterMetadata.WriterId.ToString("B"));
+                table.Add("Instance ID:", writer.WriterMetadata.InstanceId.ToString("B"));
+                if (writer.WriterMetadata.RestoreMethod == null)
+                {
+                    table.Add("Restore Method:", "No restore method specified by this writer.");
+                }
+                else
+                {
+                    table.Add("Supports restore events:", (writer.WriterMetadata.RestoreMethod.WriterRestore != VssWriterRestore.Never).ToString());
+                    table.Add("Writer restore conditions:", writer.WriterMetadata.RestoreMethod.Method);
+                    table.Add("Requires reboot after restore:", writer.WriterMetadata.RestoreMethod.RebootRequired);
+                }
+                if (!writer.WriterMetadata.ExcludeFiles.Any())
+                    table.Add("Excluded files:", "<none>");
+                else
+                    table.Add("Excluded files:", "");
+
+                Host.WriteTable(table);
+
+                foreach (VssWMFileDescriptor file in writer.WriterMetadata.ExcludeFiles)
+                {
+                    PrintFileDescription(file);
+                    Host.WriteLine();
+                }
+
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors)
+                {
+                    PrintComponent(component, detailed);
+                    Host.WriteLine();
+                }
+
+                Host.PopIndent();
+            }
+        }
+
+        private void PrintComponent(VssComponentDescriptor component, bool detailed)
+        {
+            Host.WriteHeader("Component \"{0}:{1}\"", component.WriterName, component.FullPath);
             Host.PushIndent();
+            StringTable table = new StringTable();
+            table.Add("Name:", component.ComponentName);
+            table.Add("Logical Path:", component.LogicalPath);
+            table.Add("Full Path:", component.FullPath);
+            table.Add("Caption: ", component.Caption);
+            table.Add("Type:", component.ComponentType);
+            table.Add("Is Selectable:", component.IsSelectable);
+            table.Add("Is Top Level:", component.IsTopLevel);
+            table.Add("Notify on backup complete:", component.NotifyOnBackupComplete);
+            Host.WriteTable(table);
 
-            foreach (VssWriterDescriptor writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
+            if (detailed)
             {
+                Host.WriteLine("Components:");
+                Host.PushIndent();
+                foreach (VssWMFileDescriptor file in component.Files)
+                {
+                    PrintFileDescription(file, "File");
+                    Host.WriteLine();
+                }
 
-               Host.WriteLine("* Writer '{0}':", writer.WriterMetadata.WriterName);
+                foreach (VssWMFileDescriptor file in component.DatabaseFiles)
+                {
+                    PrintFileDescription(file, "Database");
+                    Host.WriteLine();
+                }
 
-               try
-               {
-                  Host.PushIndent();
-                  foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
-                  {
-                     Host.WriteLine("- Select component {0}", component.FullPath);
-                     m_backupComponents.SetFileRestoreStatus(writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName, restoreStatus);
-                  }
-               }
-               finally
-               {
-                  Host.PopIndent();
-               }
+                foreach (VssWMFileDescriptor file in component.DatabaseLogFiles)
+                {
+                    PrintFileDescription(file, "Database Log File");
+                    Host.WriteLine();
+                }
+
+                Host.PopIndent();
             }
-         }
-         finally
-         {
-            Host.PopIndent();
-         }
-      }
 
-      internal void PostRestore()
-      {
-         Host.WriteLine("Sending the PostRestore event...");
-         m_backupComponents.PostRestore();
-      }
-   }
+            Host.WriteLine("Paths affected by this component:");
+            Host.PushIndent();
+            foreach (string path in component.AffectedPaths)
+                Host.WriteLine("{0}", path);
+            Host.PopIndent();
+
+            Host.WriteLine("Volumes affected by this component:");
+            Host.PushIndent();
+            foreach (string volume in component.AffectedVolumes)
+            {
+                string displayName;
+                try
+                {
+                    displayName = Volume.GetDisplayNameForVolume(volume);
+                }
+                catch
+                {
+                    displayName = "Not valid for local machine";
+                }
+                Host.WriteLine("{0} [{1}]", volume, displayName);
+            }
+            Host.PopIndent();
+
+            if (component.Dependencies.Any())
+            {
+                Host.WriteLine("Component Dependencies:");
+                Host.PushIndent();
+                foreach (var dependency in component.Dependencies)
+                    PrintDependency(dependency);
+                Host.PopIndent();
+            }
+
+            Host.PopIndent();
+
+        }
+
+        private void PrintDependency(VssWMDependency dependency)
+        {
+            Host.WriteLine("Dependency to \"{0}:{1}\"", dependency.ComponentName, dependency.LogicalPath);
+        }
+
+        private void PrintFileDescription(VssWMFileDescriptor file, string type = null)
+        {
+            string alternateDisplayPath = "";
+            if (!String.IsNullOrEmpty(file.AlternateLocation))
+                alternateDisplayPath = String.Format(", Alternate Location={0}" + file.AlternateLocation);
+
+            Host.PushIndent();
+            StringTable table = new StringTable();
+            if (type != null)
+                table.Add("Type:", type);
+            table.Add("Path:", file.Path);
+            table.Add("Filespec:", file.FileSpecification);
+            table.Add("Recursive:", file.IsRecursive);
+            if (!String.IsNullOrEmpty(file.AlternateLocation))
+                table.Add("Alternate Location:", file.AlternateLocation);
+
+            Host.WriteTable(table);
+            Host.PopIndent();
+        }
+
+        internal void GenerateSetvarScript(string fileName)
+        {
+            Host.WriteLine("Generating the SETVAR script ({0})... ", fileName);
+
+            using (StreamWriter writer = new StreamWriter(fileName))
+            {
+                writer.WriteLine("@echo.");
+                writer.WriteLine("@echo [This script is generated by AlphaShadow.exe for the shadow set {0:B}]", m_latestSnapshotSetId);
+                writer.WriteLine("@echo.");
+                writer.WriteLine();
+
+                writer.WriteLine("SET SHADOW_SET_ID={0:B}", m_latestSnapshotSetId);
+
+                // For each added volume add the AlphaShadow.exe exposure command
+                for (int i = 0; i < m_latestSnapshotIdList.Count; i++)
+                {
+                    Guid snapshotId = m_latestSnapshotIdList[i];
+                    writer.WriteLine("SET SHADOW_ID_{0}={1:B}", i, snapshotId);
+                    if ((m_context & VssVolumeSnapshotAttributes.Transportable) == 0)
+                    {
+                        VssSnapshotProperties properties = m_backupComponents.GetSnapshotProperties(snapshotId);
+                        writer.WriteLine("SET SHADOW_DEVICE_{0}={1}", i, properties.SnapshotDeviceObject);
+                    }
+                }
+            }
+        }
+
+        private bool BackupComplete_Before(bool succeeded)
+        {
+            if (m_backupComponents.WriterComponents.Count == 0)
+            {
+                Host.WriteLine("- There were no writer components in this backup");
+                return false;
+            }
+            else if (succeeded)
+            {
+                Host.WriteLine("- Mark all writers as successfully backed up...");
+            }
+            else
+            {
+                Host.WriteLine("- Backup failed. Mark all writers as not successfully backed up...");
+            }
+
+            SetBackupSucceeded(succeeded);
+
+            Host.WriteLine("Completing the backup (BackupComplete) ... ");
+            return true;
+        }
+
+        internal void BackupComplete(bool succeeded)
+        {
+            if (!BackupComplete_Before(succeeded)) return;
+
+            m_backupComponents.BackupComplete();
+
+            // Check selected writer status
+            CheckSelectedWriterStatus();
+        }
+
+        internal async Task BackupCompleteAsync(bool succeeded, CancellationToken cancellationToken)
+        {
+            if (!BackupComplete_Before(succeeded)) return;
+
+            await m_backupComponents.BackupCompleteAsync(cancellationToken);
+
+            // Check selected writer status
+            await CheckSelectedWriterStatusAsync(cancellationToken);
+        }
+
+
+        private void SetBackupSucceeded(bool succeeded)
+        {
+            foreach (VssWriterDescriptor writer in m_writers)
+            {
+                foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => c.IsExplicitlyIncluded))
+                {
+                    m_backupComponents.SetBackupSucceeded(writer.WriterMetadata.InstanceId,
+                       writer.WriterMetadata.WriterId,
+                       component.ComponentType,
+                       component.LogicalPath,
+                       component.ComponentName,
+                       succeeded);
+                }
+            }
+        }
+
+        internal void DeleteSnapshot(Guid snapshotId)
+        {
+            Host.WriteLine("- Deleting shadow copy {0:B}...", snapshotId);
+
+            m_backupComponents.DeleteSnapshot(snapshotId, false);
+        }
+
+        internal void DeleteSnapshotSet(Guid snapshotSetId)
+        {
+            Host.WriteLine("- Deleting shadow copy set {0:B}...", snapshotSetId);
+
+            int deletedSnapshots = m_backupComponents.DeleteSnapshotSet(snapshotSetId, false);
+
+            Host.WriteLine("{0} snapshots were successfully deleted.", deletedSnapshots);
+        }
+
+        internal void DeleteAllSnapshots()
+        {
+            // Get a list of all shadow copies
+            IList<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots().ToArray();
+
+            if (snapshots.Count == 0)
+            {
+                Host.WriteLine("There were no shadow copies on the system.");
+                return;
+            }
+
+            Host.PushIndent();
+            try
+            {
+                foreach (VssSnapshotProperties snapshot in snapshots)
+                {
+                    Host.WriteLine("- Deleting shadow copy {0:B} on {1} from provider {2} [{3}]...", snapshot.SnapshotId, snapshot.OriginalVolumeName, snapshot.ProviderId, snapshot.SnapshotAttributes);
+                    m_backupComponents.DeleteSnapshot(snapshot.SnapshotId, false);
+                }
+            }
+            finally
+            {
+                Host.PopIndent();
+            }
+        }
+
+        internal void DeleteOldestSnapshot(string volume)
+        {
+            string uniqueVolume = Volume.GetUniqueVolumeNameForPath(Host, volume, false);
+            IList<VssSnapshotProperties> snapshots = m_backupComponents.QuerySnapshots().ToArray();
+
+            if (snapshots.Count == 0)
+            {
+                Host.WriteLine("There are now shadow copies in the system.");
+                return;
+            }
+
+            VssSnapshotProperties snapshot = snapshots
+               .Where(snap => snap.OriginalVolumeName.Equals(uniqueVolume, StringComparison.OrdinalIgnoreCase))
+               .OrderBy(snap => snap.CreationTimestamp).FirstOrDefault();
+
+            if (snapshot == null)
+            {
+                Host.WriteLine("There are no shadow copies for the specified volume in the system.");
+                return;
+            }
+
+            Host.WriteLine("- Deleting shadow copy {0:B} on {1} from provider {2} [{3}]...", snapshot.SnapshotId, snapshot.OriginalVolumeName, snapshot.ProviderId, snapshot.SnapshotAttributes);
+            m_backupComponents.DeleteSnapshot(snapshot.SnapshotId, false);
+        }
+
+        internal void RevertToSnapshot(Guid snapshotId)
+        {
+            VssSnapshotProperties snapshot = m_backupComponents.GetSnapshotProperties(snapshotId);
+
+            Host.WriteLine("Reverting to shadow copy {0:B} on {1} from provider {2:B} [{3}]...",
+               snapshot.SnapshotId,
+               snapshot.OriginalVolumeName,
+               snapshot.ProviderId,
+               snapshot.SnapshotAttributes);
+
+            if (s_implementation.ShouldBlockRevert(snapshot.OriginalVolumeName))
+            {
+                Host.WriteWarning("Revert is disabled on the volume {0} because of writers.", snapshot.OriginalVolumeName);
+                return;
+            }
+
+            m_backupComponents.RevertToSnapshot(snapshot.SnapshotId, true);
+
+            IVssAsyncResult ar = m_backupComponents.BeginQueryRevertStatus(snapshot.OriginalVolumeName, null, null);
+            m_backupComponents.EndQueryRevertStatus(ar);
+
+            Host.WriteLine("The shadow copy has been successfully reverted.");
+        }
+
+        // Return the list of snapshot volume devices in this snapshot set
+        private IList<string> GetSnapshotDevices(Guid snapshotSetID)
+        {
+            List<string> volumes = new List<string>();
+            foreach (VssSnapshotProperties snapshot in m_backupComponents.QuerySnapshots().Where(snap => snap.SnapshotSetId == snapshotSetID))
+            {
+                // Get the snapshot device object name which is a volume guid name for persistent snapshot
+                // and a device name for non persistent snapshot.
+                // The volume guid name and the device name we obtained here might change after breaksnapshot
+                // depending on if the disk signature is reverted, but those cached names should still work
+                // as symbolic links, in which case they can not persist after reboot.
+                Host.WriteLine("Will convert {0} to read-write...", snapshot.SnapshotDeviceObject);
+                volumes.Add(snapshot.SnapshotDeviceObject);
+            }
+
+            return volumes;
+        }
+
+
+        internal void ExposeShapshotLocally(Guid snapshotId, string path)
+        {
+            Host.WriteLine("Exposing shadow copy {0:B} under the path '{1}'", snapshotId, path);
+
+            VerifyExposeSnapshot(snapshotId);
+
+            // Check if the path parameter is valid
+            if (path.Length == 2 && path.EndsWith(":"))
+            {
+                Host.WriteLine("Checking if '{0}' is a valid drive letter...", path);
+
+                try
+                {
+                    Volume.QueryDosDevice(path);
+                    throw new ArgumentException(String.Format("The specified mount point [{0}] is a drive letter already in use.", path));
+                }
+                catch (Win32Exception ex)
+                {
+                    if (ex.NativeErrorCode != 2)
+                        throw;
+                }
+
+            }
+            else
+            {
+                path = path.AppendBackslash();
+
+                Host.WriteLine("Checking if '{0} is a valid empty directory...", path);
+
+                if (!Directory.Exists(path))
+                    throw new ArgumentException(String.Format("The specified mount point [{0}] is not a valid directory.", path));
+
+                if (Directory.GetFileSystemEntries(path).Any())
+                    throw new ArgumentException(String.Format("The specified mount point [{0}] is not an empty directory.", path));
+
+            }
+            // Expose the snapshot locally 
+            m_backupComponents.ExposeSnapshot(snapshotId, null, VssVolumeSnapshotAttributes.ExposedLocally, path);
+
+            Host.WriteLine("Shadow copy exposed as '{0}'", path);
+        }
+
+        private void VerifyExposeSnapshot(Guid snapshotId)
+        {
+            // Make sure that the expose operation is valid for this snapshot.
+            // Get the shadow copy properties
+            VssSnapshotProperties props;
+            try
+            {
+                props = m_backupComponents.GetSnapshotProperties(snapshotId);
+            }
+            catch (VssObjectNotFoundException)
+            {
+                throw new ArgumentException("There is no snapshot with the given id.");
+            }
+
+            // Client Accessible snapshots are not exposable
+            if ((props.SnapshotAttributes & VssVolumeSnapshotAttributes.ClientAccessible) != 0)
+                throw new ArgumentException("The snapshot id identifies a client accessible snapshot which cannot be exposed.");
+
+            if (!String.IsNullOrEmpty(props.ExposedName) || !String.IsNullOrEmpty(props.ExposedPath))
+                throw new ArgumentException("Client-accessible (SFSF) snapshots cannot be exposed.");
+        }
+
+        internal void ExposeSnapshotRemotely(Guid snapshotId, string shareName, string pathFromRoot)
+        {
+            pathFromRoot = String.IsNullOrEmpty(pathFromRoot) ? null : pathFromRoot;
+
+            Host.WriteLine("Exposing shadow copy {0:B} under the share '{1}' (path from root: '{2}')", snapshotId, shareName, pathFromRoot ?? "");
+
+            VerifyExposeSnapshot(snapshotId);
+
+            // Note: a true reqester should also check here if 
+            // - the remote share name is valid (i.e. unused)
+            // - the path from root is valid
+            m_backupComponents.ExposeSnapshot(snapshotId, pathFromRoot, VssVolumeSnapshotAttributes.ExposedRemotely, shareName);
+        }
+
+        internal void ImportSnapshotSet()
+        {
+            Host.WriteLine("Importing the transportable shadow copy...");
+
+            m_backupComponents.ImportSnapshots();
+
+            Host.WriteLine("Shadow copy set successfully imported.");
+        }
+
+        internal async Task ImportSnapshotSetAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Importing the transportable shadow copy...");
+
+            await m_backupComponents.ImportSnapshotsAsync(cancellationToken);
+
+            Host.WriteLine("Shadow copy set successfully imported.");
+        }
+
+        internal void InitializeWriterComponentsForRestore()
+        {
+            Host.WriteLine("Initializing writer components for restore...");
+
+            m_writerComponentsForRestore = new List<VssWriterDescriptor>();
+
+            bool found = false;
+            // Enumerate the list of writers in the metadata  
+            foreach (IVssWriterComponents components in m_backupComponents.WriterComponents)
+            {
+                // Try to discover the name based on an existing writer (identical ID and instance ID).
+                // Otherwise, ignore it!
+                foreach (VssWriterDescriptor writer in m_writers)
+                {
+                    // Do not check for instance id.
+                    if (components.WriterId != writer.WriterMetadata.WriterId)
+                        continue;
+
+                    Host.WriteLine("Writer {0} is present in the Backup Components document and on the system. Considering for restore...", writer.WriterMetadata.WriterName);
+
+                    // Adding components
+                    writer.InitializeComponentsForRestore(components);
+
+                    m_writerComponentsForRestore.Add(writer);
+
+                    found = true;
+                }
+
+                if (!found)
+                {
+                    Host.WriteLine("Writer with ID {0:B} is not present in the system. Ignoring...", components.WriterId);
+                }
+            }
+        }
+
+        internal void SelectComponentsForRestore(IList<string> excludedWriterAndComponentList, IList<string> includedWriterAndComponentList)
+        {
+            // First, exclude all components that have data outside of the shadow set
+            DiscoverDirectlyExcludedComponents(excludedWriterAndComponentList, m_writerComponentsForRestore);
+
+            // Exclude all writers that do not support restore events
+            ExcludeWritersWithNoRestoreEvents();
+
+            Host.WriteLine("Verifying explicitly specified writers/components...");
+
+            foreach (string inc in includedWriterAndComponentList)
+            {
+                if (inc.Contains(':'))
+                    VerifyExplicitlyIncludedComponent(inc, m_writerComponentsForRestore);
+                else
+                    VerifyExplicitlyIncludedWriter(inc, m_writerComponentsForRestore);
+            }
+
+            // Finally, select the explicitly included components
+            SelectNonexcludedComponentsForRestore();
+        }
+
+        private void SelectNonexcludedComponentsForRestore()
+        {
+            Host.WriteLine("Select components for restore...");
+
+            Host.PushIndent();
+            try
+            {
+                foreach (VssWriterDescriptor writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
+                {
+                    Host.WriteLine("* Writer '{0}':", writer.WriterMetadata.WriterName);
+
+                    Host.PushIndent();
+                    try
+                    {
+                        // Compute the roots of included components
+                        foreach (var component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
+                        {
+                            Host.WriteLine("- Select component {0}", component.FullPath);
+                            m_backupComponents.SetSelectedForRestore(writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName, true);
+                        }
+                    }
+                    finally
+                    {
+                        Host.PopIndent();
+                    }
+                }
+            }
+            finally
+            {
+                Host.PopIndent();
+            }
+        }
+
+        private void ExcludeWritersWithNoRestoreEvents()
+        {
+            Host.WriteLine("Exclude writers that do not support restore events...");
+
+
+            foreach (var writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
+            {
+                if (writer.WriterMetadata.RestoreMethod.WriterRestore == VssWriterRestore.Never)
+                {
+                    Host.WriteLine("Excluding writer '{0}' since it does not support restore events.", writer.WriterMetadata.WriterName);
+                    writer.IsExcluded = true;
+                }
+            }
+        }
+
+        internal void PreRestore()
+        {
+            Host.WriteLine("Sending the PreRestore event...");
+            m_backupComponents.PreRestore();
+        }
+
+        internal Task PreRestoreAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Sending the PreRestore event...");
+            return m_backupComponents.PreRestoreAsync(cancellationToken);
+        }
+
+        internal void SetFileRestoreStatus(bool successfullyRestored)
+        {
+            Host.WriteLine("Set restore status for all components for restore...");
+
+            // All-or-nothing policy
+            //
+            // WARNING: this might be insufficient since we cannot distinguish
+            // between a partial failed restore and a completely failed restore!
+            // A true requester should be able to make this difference (see the documentation for more details)
+            VssFileRestoreStatus restoreStatus = successfullyRestored ? VssFileRestoreStatus.All : VssFileRestoreStatus.None;
+
+            try
+            {
+                Host.PushIndent();
+
+                foreach (VssWriterDescriptor writer in m_writerComponentsForRestore.Where(w => !w.IsExcluded))
+                {
+
+                    Host.WriteLine("* Writer '{0}':", writer.WriterMetadata.WriterName);
+
+                    try
+                    {
+                        Host.PushIndent();
+                        foreach (VssComponentDescriptor component in writer.ComponentDescriptors.Where(c => !c.IsExcluded))
+                        {
+                            Host.WriteLine("- Select component {0}", component.FullPath);
+                            m_backupComponents.SetFileRestoreStatus(writer.WriterMetadata.WriterId, component.ComponentType, component.LogicalPath, component.ComponentName, restoreStatus);
+                        }
+                    }
+                    finally
+                    {
+                        Host.PopIndent();
+                    }
+                }
+            }
+            finally
+            {
+                Host.PopIndent();
+            }
+        }
+
+        internal void PostRestore()
+        {
+            Host.WriteLine("Sending the PostRestore event...");
+            m_backupComponents.PostRestore();
+        }
+
+        internal Task PostRestoreAsync(CancellationToken cancellationToken)
+        {
+            Host.WriteLine("Sending the PostRestore event...");
+            return m_backupComponents.PostRestoreAsync(cancellationToken);
+        }
+    }
 }

--- a/src/Samples/AlphaShadow/packages.config
+++ b/src/Samples/AlphaShadow/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Hello,

This is another attempt at issue #1 . I added task-based methods for the ones that now follow the APM pattern (Begin/End). I.e. method `BackupComplete` can be run async using the new method `BackupCompleteAsync`, instead of using `BeginBackupComplete` and `EndBackupComplete`. 

How it works: The VSS method `BackupComplete` is executed on the caller's thread, then a task is scheduled to wait for completion on another thread and the task is returned to the caller. The caller can then await the task. (See examples in AlphaShadow).

Features:
- the task scheduling is managed by a  task factory that the user can set using `VssUtils.TaskFactory`. This should be done once per app. When tasks are scheduled, they use this factory's task scheduler. In case the task factory is not set by user, a default task factory is used whose task scheduler is `TaskScheduler.Default` (the one that uses threads from the thread pool).
- each async method can use a `CancellationToken` to cancel the operation async.

I didn't add documentation yet. I will do so if you agree on these changes.

Hope this helps.