### PR TITLE
Fix 32-bit / 64-bit detection

### DIFF
--- a/src/AlphaVSS.Common/Classes/VssUtils.cs
+++ b/src/AlphaVSS.Common/Classes/VssUtils.cs
@@ -33,7 +33,7 @@ namespace Alphaleonis.Win32.Vss
       {
          StringBuilder result = new StringBuilder("AlphaVSS.");
 
-         if (Environment.Is64BitOperatingSystem)
+         if (IntPtr.Size == 8)
             result.Append("x64");
          else
             result.Append("x86");         


### PR DESCRIPTION
Fix for issue #26 

According to [this question on Stack Overflow](https://stackoverflow.com/questions/266082/how-do-i-tell-if-my-application-is-running-as-a-32-bit-or-64-bit-application), we should check on IntPtr.Size to see if we run on 32-bit or 64-bit mode.

The previous verification would always load 64-bit assembly on a 64-bit OS, even if the app runs on 32-bit mode.